### PR TITLE
Improve caching and automate builds via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - echo "Build finished"
 after_success:
-  - if [[ "$TRAVIS_BRANCH" = "travis" ]]; then
+  - if [[ "$TRAVIS_BRANCH" = "master" ]]; then
       echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_LOGIN --password-stdin;
       docker push nextstrain/base-builder;
       docker push nextstrain/base;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# The nextstrain/base Dockerfile is a multi-stage with both a "builder" target
+# and a main target. To enable proper caching via --cache-from we need both
+# these images available to pull layers from. This means pulling both in at the
+# start and pushing both up at the end.
+# Calling `docker run nextstrain/base` will still only pull down the small base image
+# rather than pulling down the larger nextstrain/base-builder image
+services:
+  - docker
+sudo: required
+before_install:
+  - docker pull nextstrain/base-builder
+  - docker pull nextstrain/base
+install:
+  - docker build --cache-from nextstrain/base-builder --cache-from nextstrain/base -t nextstrain/base-builder --target builder .
+  - docker build --cache-from nextstrain/base-builder --cache-from nextstrain/base -t nextstrain/base .
+script:
+  - echo "Build finished"
+after_success:
+  - if [[ "$TRAVIS_BRANCH" = "travis" ]]; then
+      echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_LOGIN --password-stdin;
+      docker push nextstrain/base-builder;
+      docker push nextstrain/base;
+    fi

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ use case, which is somewhat atypical.
 The [Dockerfile reference documentation][] is quite handy for looking up the
 details of each Dockerfile command (`COPY`, `ADD`, etc).
 
+### Continuous integration
+
+The Docker image is automatically built with Travis CI and pushed to the Docker registry. The most recent build can be seen at [travis-ci.com/nextstrain/docker-base/](https://travis-ci.com/nextstrain/docker-base/) and Travis CI build instructions can be found in this repo's `.travis.yml` file.
+
 [`nextstrain/base`]: https://hub.docker.com/r/nextstrain/base/
 [Alpine Linux]: https://alpinelinux.org
 [Alpine Linux package index]: https://pkgs.alpinelinux.org/packages?branch=v3.7&repo=main&arch=x86_64


### PR DESCRIPTION
@tsibley ---

Just updating you on why I did things the way I did. I had noticed that automated builds were taking ~40 minutes on Docker Hub. This was because Docker Hub does not attempt any caching for automated builds. Consequently, I experimented with running automated builds on Quay.io and Docker Cloud, which both theoretically allow caching. However, I couldn't get it to work with either. In both there is no control over the `docker build` command called after a GitHub push.

Consequently, I moved things over to Travis CI, which provides full control over the build. I was able to get caching working there via `--cache-from`. Builds now take 3 minutes if nothing has changed and ~6 minutes if something has. If the Travis CI build is successful, then `docker push` is run to update the `nextstrain/base` image. We effectively get the same behavior as a Docker Hub automated build, but with much more control over the process.

I also like having this done on Travis CI as puts all our continuous integration into a single place, so we don't have to also check Docker Hub (or whatever) to see if Docker image builds are working.

To get caching working I needed to add a number of `pip install` commands to the Dockerfile, otherwise `biopython`, etc... install from scratch each time. Generally, rebuilding should happen from line 92 of the Dockerfile: https://github.com/nextstrain/docker-base/blob/travis/Dockerfile#L92 and restore `biopython`, etc... from cached layers.  Please let me know if this approach isn't clear.

There was also a trick to get `--cache-from` working for a multi-stage build, described here: and this tutorial: https://github.com/moby/moby/issues/34715. Take a look at the `.travis.yml` file for more details.