### PR TITLE
Fix our usage of $TRAVIS_BRANCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 script:
   - echo "Build finished"
 after_success:
-  - if [[ "$TRAVIS_BRANCH" = "master" ]]; then
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
       echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_LOGIN --password-stdin;
       docker push nextstrain/base-builder;
       docker push nextstrain/base;


### PR DESCRIPTION
For jobs triggered by push, $TRAVIS_BRANCH is the branch name, as
expected.

For jobs triggered by PRs, $TRAVIS_BRANCH is the _destination_ branch
name, i.e. the stable branch (usually master) that the feature branch is
intended to be merged into (and Travis tests the merge).

More details here, as noted by James:

  https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/

We don't ever want to update our default live Docker images for PRs.  We
only want to do so after PRs/branches are merged and pushed to master.