### PR TITLE
Push unique image tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,29 @@ services:
   - docker
 sudo: required
 before_install:
+  - export DATESTRING=$(date +%F-%H-%M-%S)
   - docker pull nextstrain/base-builder
   - docker pull nextstrain/base
 install:
   - |
-    docker build --build-arg CACHE_DATE="$(date)" \
+    docker build --build-arg CACHE_DATE=$DATESTRING \
       --cache-from nextstrain/base-builder \
       --cache-from nextstrain/base \
-      -t nextstrain/base-builder --target builder .
+      -t nextstrain/base-builder:latest --target builder .
   - |
-    docker build --build-arg CACHE_DATE="$(date)" \
+    docker build --build-arg CACHE_DATE=$DATESTRING \
       --cache-from nextstrain/base-builder \
       --cache-from nextstrain/base \
-      -t nextstrain/base .
+      -t nextstrain/base:latest .
 script:
   - echo "Build finished"
 after_success:
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
       echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_LOGIN --password-stdin;
-      docker push nextstrain/base-builder;
-      docker push nextstrain/base;
+      docker push nextstrain/base-builder:latest;
+      docker push nextstrain/base:latest;
+      docker tag nextstrain/base-builder:latest nextstrain/base-builder:$DATESTRING;
+      docker tag nextstrain/base:latest nextstrain/base:$DATESTRING;
+      docker push nextstrain/base-builder:$DATESTRING;
+      docker push nextstrain/base:$DATESTRING;
     fi


### PR DESCRIPTION
@tsibley ---

This PR gives every build / image a unique tag. I chose to use a date string for this. This was following advice here: https://blogs.msdn.microsoft.com/stevelasker/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/. This would allow the cli to refer to a specific image version rather than just latest. 

This was tested on Travis CI and resulted in the tag `2018-08-04-21-46-25` seen here: https://hub.docker.com/r/nextstrain/base/tags/.

I'm not at all wedded to the date string as tag, if you have better idea. Date string did seem offer convenience and to be easily understandable. I don't think we can use a proper version here.