### PR TITLE
Build image using auspice release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN curl -fsSL https://api.github.com/repos/nextstrain/augur/tarball/master \
 # auspice
 WORKDIR /nextstrain/auspice
 
-RUN curl -fsSL https://api.github.com/repos/nextstrain/auspice/tarball/master \
+RUN curl -fsSL https://api.github.com/repos/nextstrain/auspice/tarball/release \
   | tar xzvpf - --strip-components=1
 
 


### PR DESCRIPTION
@tsibley ---

We want a stable call to `nextstrain view`. Better to have the Docker image `latest` tag refer to `release` branch of auspice and only update the Docker image when `release` branch is updated, rather than when `master` is updated.

Currently, auspice Travis CI script properly pings the `docker-base` rebuild only when auspice `release` is pushed: https://github.com/nextstrain/auspice/blob/master/.travis.yml#L11. This change brings `docker-base` in line.

Once we have a `release` branch and proper versioning in augur, I would swap augur to do the same.