### PR TITLE
Add labels to the image to track metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,3 +220,25 @@ RUN chmod a+rx /sbin/entrypoint
 WORKDIR /nextstrain/build
 
 ENTRYPOINT ["/sbin/entrypoint"]
+
+# Finally, add metadata at the end so it doesn't bust cached layers.
+#
+# Optionally passed in during build.  Used by a label below.
+ARG GIT_REVISION
+
+# Add some metadata to our image for searching later.  The "maintainer" label
+# is community convention and comes from the old MAINTAINER command.  Other
+# labels should be namedspaced a la Java classes.  We mostly use the keys
+# defined in the OpenContainers spec:
+#
+#   https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+#
+# The custom "org.nextstrain.image.name" label in particular will likely be
+# used by nextstrain-cli's image pruning, as labels are the only way to have
+# persistent metadata values (tags are removed from old images after pulling a
+# new image with the tag).
+LABEL maintainer="Nextstrain team <hello@nextstrain.org>"
+LABEL org.opencontainers.image.authors="Nextstrain team <hello@nextstrain.org>"
+LABEL org.opencontainers.image.source="https://github.com/nextstrain/docker-base"
+LABEL org.opencontainers.image.revision="${GIT_REVISION}"
+LABEL org.nextstrain.image.name="nextstrain/base"

--- a/devel/build
+++ b/devel/build
@@ -9,6 +9,7 @@
 #
 set -euo pipefail
 
+export GIT_REVISION=$(git describe --tags --abbrev=40 --always --dirty || true)
 
 # The nextstrain/base Dockerfile is a multi-stage with both a "builder" target
 # and a main target.  To enable proper caching via --cache-from we need both
@@ -20,6 +21,7 @@ set -euo pipefail
 
 docker build \
     --build-arg CACHE_DATE \
+    --build-arg GIT_REVISION \
     --cache-from nextstrain/base-builder \
     --cache-from nextstrain/base \
     --tag nextstrain/base-builder \
@@ -28,6 +30,7 @@ docker build \
 
 docker build \
     --build-arg CACHE_DATE \
+    --build-arg GIT_REVISION \
     --cache-from nextstrain/base-builder \
     --cache-from nextstrain/base \
     --tag nextstrain/base \


### PR DESCRIPTION
Metadata is useful for identifying images later, especially if they've
been untagged locally by newer versions.

The nextstrain-cli also needs to be able to identify our images for
automatic pruning.  It will use org.nextstrain.image.name to do this.