### PR TITLE
Record versions/git ids of individual Nextstrain components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,29 +101,20 @@ RUN pip3 install envdir
 # docker build --build-arg CACHE_DATE="$(date)"
 ARG CACHE_DATE
 
-# sacra
-WORKDIR /nextstrain/sacra
+# Add download helper
+COPY devel/download-repo /devel/
 
-RUN curl -fsSL https://api.github.com/repos/nextstrain/sacra/tarball/master \
-  | tar xzvpf - --strip-components=1
+# sacra
+RUN /devel/download-repo https://github.com/nextstrain/sacra /nextstrain/sacra
 
 # fauna
-WORKDIR /nextstrain/fauna
-
-RUN curl -fsSL https://api.github.com/repos/nextstrain/fauna/tarball/master \
-  | tar xzvpf - --strip-components=1
+RUN /devel/download-repo https://github.com/nextstrain/fauna /nextstrain/fauna
 
 # augur
-WORKDIR /nextstrain/augur
-
-RUN curl -fsSL https://api.github.com/repos/nextstrain/augur/tarball/master \
-  | tar xzvpf - --strip-components=1
+RUN /devel/download-repo https://github.com/nextstrain/augur /nextstrain/augur
 
 # auspice
-WORKDIR /nextstrain/auspice
-
-RUN curl -fsSL https://api.github.com/repos/nextstrain/auspice/tarball/release \
-  | tar xzvpf - --strip-components=1
+RUN /devel/download-repo https://github.com/nextstrain/auspice /nextstrain/auspice
 
 
 # Install Python 2 deps

--- a/devel/download-repo
+++ b/devel/download-repo
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+src="$1"
+dst="$2"
+
+# Create the destination directory and move into it
+mkdir -p "$dst"
+cd "$dst"
+
+# Clone the source repo into the destination, shallowly
+git clone --depth=20 "$src" .
+
+# Record the git revision (always a sha) and id (based on the closest tag)
+git rev-parse HEAD > .GIT_REVISION
+git describe --always --dirty > .GIT_ID
+
+# Clean up the git history; we needed it above but the image does not.
+rm -rf .git


### PR DESCRIPTION
These are useful to have for debugging and inspecting what's in an
image.  Baking them into the image itself is handy because it means they
won't be misleading when/if a local copy of auspice or augur is
overlaid.

Resolves #13.