### PR TITLE
Update snakemake to support --set-threads argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN pip3 install phylo-treetime==0.7.4
 RUN pip3 install requests==2.20.0
 RUN pip3 install rethinkdb==2.3.0.post6
 RUN pip3 install seaborn==0.9.0
-RUN pip3 install snakemake==5.8.1
+RUN pip3 install snakemake==5.10.0
 RUN pip3 install unidecode==1.0.22
 RUN pip3 install xlrd==1.0.0
 


### PR DESCRIPTION
The current Docker image has Snakemake version 5.8.1, but when running builds on AWS, we need access to the `--set-threads` argument that was added in version 5.10.0. This PR updates the Docker image to this later version of Snakemake which also happens to be the latest version currently supported by augur.