### PR TITLE
update mafft to latest version 7.475 -- required for reference alignm…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
 
 # mafft
 WORKDIR /build/mafft
-RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.402-linux.tgz \
+RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
   | tar xzvpf - --strip-components=2 mafft-linux64/mafftdir/
 
 # RAxML


### PR DESCRIPTION
…ents in ncov

### Description of proposed changes    
A recent mafft version is required for the alignment to reference that we now use in ncov

Related to/replaces #22 

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
