### PR TITLE
Install Augur's "full" extra deps automatically instead of inlining them separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,14 +91,7 @@ RUN pip3 install --requirement=/nextstrain/fauna/requirements.txt
 # Augur is an editable install so we can overlay the augur version in the image
 # with --volume=.../augur:/nextstrain/augur and still have it globally
 # accessible and importable.
-RUN pip3 install --editable /nextstrain/augur
-
-# Install additional "full" dependencies for augur.
-# TODO: these versions should be updated in augur's setup.py to work with the
-# pip install nextstrain-augur[full] approach.
-RUN pip3 install cvxopt==1.2.4
-RUN pip3 install matplotlib==2.2.2
-RUN pip3 install seaborn==0.9.0
+RUN pip3 install --editable "/nextstrain/augur[full]"
 
 # Install pathogen-specific workflow dependencies. Since we only maintain a
 # single Docker image to support all pathogen workflows, some pathogen-specific


### PR DESCRIPTION
The only notable difference at the moment is the version of cvxopt,
which is 1.2.x here, but 1.1.x in Augur's setup.py at the moment.
@huddlej notes that the Augur bioconda recipe actually uses 1.x and
Augur's setup.py should be separately updated to reflect a more lenient
version.

That original reason Augur's deps were explicitly inlined into the
Dockerfile here was to avoid lengthy image rebuilds.  That was done
because several of the deps didn't have wheels for Alpine, so had to be
compiled from source.  With the new Debian image base, we should be able
to rely on wheels, so installing the deps every time won't be much of a
burden and very much worth the simplicity of having a single source of
truth.
