### PR TITLE
Add epiweeks as a workflow-specific dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,15 @@ RUN pip3 install cvxopt==1.2.4
 RUN pip3 install matplotlib==2.2.2
 RUN pip3 install seaborn==0.9.0
 
+# Install pathogen-specific workflow dependencies. Since we only maintain a
+# single Docker image to support all pathogen workflows, some pathogen-specific
+# functionality must live in this Dockerfile. The following dependencies may be
+# used by multiple pathogen workflows, but they have been commented according to
+# the original pathogen that added these dependencies.
+
+# ncov
+RUN pip3 install epiweeks==2.1.2
+
 # Install Node deps, build Auspice, and link it into the global search path.  A
 # fresh install is only ~40 seconds, so we're not worrying about caching these
 # as we did the Python deps.  Building auspice means we can run it without


### PR DESCRIPTION
## Description of proposed changes

The ncov workflow annotates epiweeks from dates to more effectively communicate dates with epidemiologists and allow epi users to color and filter data by these annotations. This commit adds the Python `epiweeks` package as a dependency, to support epiweek annotations for ncov workflow users who rely on the Docker image.

## Related issue(s)

Required for https://github.com/nextstrain/ncov/pull/703
Related to https://github.com/nextstrain/docker-base/issues/33

## Testing

 - [x] CI