### PR TITLE
Add Pangolin to nextstrain-base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,6 @@ COPY --from=builder /usr/local/lib/python3.7/site-packages/ /usr/local/lib/pytho
 # troublesome or excessive.
 #   -trs, 15 June 2018
 COPY --from=builder \
-    /usr/local/bin/*.py \
     /usr/local/bin/augur \
     /usr/local/bin/aws \
     /usr/local/bin/envdir \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
         curl \
+        git \
         gzip \
         nodejs \
         perl \
@@ -150,6 +151,15 @@ COPY --from=builder \
 
 COPY --from=builder /build/vcftools/built/bin/    /usr/local/bin/
 COPY --from=builder /build/vcftools/built/share/  /usr/local/share/
+
+# Add Pangolin and PangoLEARN + deps
+RUN curl -fsSL https://github.com/virus-evolution/gofasta/releases/download/v0.0.6/gofasta-linux-amd64 \
+        -o /usr/local/bin/gofasta \
+  && chmod a+rx /usr/local/bin/gofasta
+RUN cd /usr/local/bin && curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
+  | tar xjvpf - --strip-components=1 minimap2-2.24_x64-linux/minimap2
+RUN pip install git+https://github.com/cov-lineages/pangolin.git@v2.3.8
+RUN pip install git+https://github.com/cov-lineages/pangoLEARN.git@2021-04-01
 
 # Add Nextalign
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-Linux-x86_64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         xz-utils \
         zip unzip
 
-
 # Configure the prompt for interactive usage
 COPY prompt.sh /etc/profile.d/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,45 +132,6 @@ RUN cd /nextstrain/auspice && npm update && npm install && npm run build && npm 
 
 # ———————————————————————————————————————————————————————————————————— #
 
-# UShER is a pangolin 3+ dependency.
-FROM python:3.7-slim-buster as usher
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -yq --no-install-recommends \
-    automake \
-    build-essential \
-    cmake \
-    curl \
-    ca-certificates \
-    libboost-date-time-dev \
-    libboost-filesystem-dev \
-    libboost-iostreams-dev \
-    libboost-program-options-dev \
-    libmpich-dev \
-    libprotoc-dev \
-    libprotoc-dev protobuf-compiler \
-    libtbb-dev \
-    libtool \
-    mafft \
-    mpich \
-    nasm
-
-WORKDIR /usr/local/lib/
-RUN curl -fsSL https://github.com/intel/isa-l/archive/refs/tags/v2.30.0.tar.gz \
-  | tar xzvpf -
-WORKDIR /usr/local/lib/isa-l-2.30.0
-RUN ./autogen.sh && ./configure && make -j 2 && make install
-WORKDIR /usr/local/lib/
-RUN curl  -fsSL https://github.com/oneapi-src/oneTBB/archive/2019_U9.tar.gz \
-  | tar xzvpf -
-RUN curl -fsSL https://github.com/yatisht/usher/archive/refs/tags/v0.5.2.tar.gz \
-  | tar xzvpf -
-WORKDIR /usr/local/lib/usher-0.5.2
-## Checkout latest release
-RUN cmake  -DTBB_DIR=/usr/local/lib/oneTBB-2019_U9 -DCMAKE_PREFIX_PATH=/usr/local/lib/oneTBB-2019_U9/cmake .
-RUN make -j2 VERBOSE=1
-
-# ———————————————————————————————————————————————————————————————————— #
-
 # Now build the final image.
 FROM python:3.7-slim-buster
 
@@ -188,15 +149,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zip unzip
 
 
-# Add UShER runtime deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libboost-date-time1.67.0 \
-    libboost-filesystem1.67.0 \
-    libboost-iostreams1.67.0 \
-    libboost-program-options1.67.0 \
-    libboost-regex1.67.0 \
-    libprotoc17
-
 # Configure the prompt for interactive usage
 COPY prompt.sh /etc/profile.d/
 
@@ -212,10 +164,6 @@ COPY --from=builder \
 
 COPY --from=builder /build/vcftools/built/bin/    /usr/local/bin/
 COPY --from=builder /build/vcftools/built/share/  /usr/local/share/
-
-# Install UShER
-COPY --from=usher /usr/local/lib/usher-0.5.2/usher /usr/local/bin/usher
-COPY --from=usher /usr/local/lib/usher-0.5.2/tbb_cmake_build/tbb_cmake_build_subdir_release/ /usr/local/lib/usher-0.5.2/tbb_cmake_build/tbb_cmake_build_subdir_release/
 
 # Add Nextalign
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-Linux-x86_64 \
@@ -247,6 +195,7 @@ COPY --from=builder \
     /usr/local/bin/nextstrain \
     /usr/local/bin/pangolin \
     /usr/local/bin/pangolearn.smk \
+    /usr/local/bin/scorpio \
     /usr/local/bin/snakemake \
     /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,16 @@ RUN pip3 install seaborn==0.9.0
 # ncov
 RUN pip3 install epiweeks==2.1.2
 
+# Add Pangolin and PangoLEARN + deps
+RUN curl -fsSL https://github.com/virus-evolution/gofasta/releases/download/v0.0.6/gofasta-linux-amd64 \
+        -o /usr/local/bin/gofasta \
+  && chmod a+rx /usr/local/bin/gofasta
+RUN cd /usr/local/bin && curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
+  | tar xjvpf - --strip-components=1 minimap2-2.24_x64-linux/minimap2
+RUN pip install git+https://github.com/cov-lineages/pangolin.git@v2.3.8
+RUN pip install git+https://github.com/cov-lineages/pangoLEARN.git@2021-04-01
+
+
 # Install Node deps, build Auspice, and link it into the global search path.  A
 # fresh install is only ~40 seconds, so we're not worrying about caching these
 # as we did the Python deps.  Building auspice means we can run it without
@@ -127,7 +137,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
         curl \
-        git \
         gzip \
         nodejs \
         perl \
@@ -152,15 +161,6 @@ COPY --from=builder \
 COPY --from=builder /build/vcftools/built/bin/    /usr/local/bin/
 COPY --from=builder /build/vcftools/built/share/  /usr/local/share/
 
-# Add Pangolin and PangoLEARN + deps
-RUN curl -fsSL https://github.com/virus-evolution/gofasta/releases/download/v0.0.6/gofasta-linux-amd64 \
-        -o /usr/local/bin/gofasta \
-  && chmod a+rx /usr/local/bin/gofasta
-RUN cd /usr/local/bin && curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
-  | tar xjvpf - --strip-components=1 minimap2-2.24_x64-linux/minimap2
-RUN pip install git+https://github.com/cov-lineages/pangolin.git@v2.3.8
-RUN pip install git+https://github.com/cov-lineages/pangoLEARN.git@2021-04-01
-
 # Add Nextalign
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-Linux-x86_64 \
         -o /usr/local/bin/nextalign \
@@ -182,10 +182,15 @@ COPY --from=builder /usr/local/lib/python3.7/site-packages/ /usr/local/lib/pytho
 # troublesome or excessive.
 #   -trs, 15 June 2018
 COPY --from=builder \
+    /usr/local/bin/*.py \
     /usr/local/bin/augur \
     /usr/local/bin/aws \
     /usr/local/bin/envdir \
+    /usr/local/bin/gofasta \
+    /usr/local/bin/minimap2 \
     /usr/local/bin/nextstrain \
+    /usr/local/bin/pangolin \
+    /usr/local/bin/pangolearn.smk \
     /usr/local/bin/snakemake \
     /usr/local/bin/
 


### PR DESCRIPTION
### Description of proposed changes    
This adds Pangolin to nextstrain-base docker image. I'm not sure specifically which version of pangolin we want to include, so I used the versions mentioned in the GitHub issue. Just let me know if I should update this!

### Related issue(s)  
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #33 

### Testing
I've rebuilt the docker image and Pangolin runs successfully:

```
% ./devel/build
<output omitted>
% docker run -ti --rm=true nextstrain/base -- sh -c 'pangolin /usr/local/lib/python3.7/site-packages/pangolin/data/reference.fasta 2> /dev/null && echo output: && cat lineage_report.csv'
Found the snakefile
Do things with sam files

Usage:
  gofasta sam [flags]
  gofasta sam [command]

Available Commands:
  indels       Parse a SAM file for raw indel information
  toMultiAlign Convert a SAM file to a multiple alignment in fasta format
  toPairAlign  convert a SAM file to pairwise alignments in fasta format
  variants     Find mutations relative to a reference from an alignment in sam format

Flags:
  -h, --help               help for sam
  -r, --reference string   Reference fasta file used to generate the sam file
  -s, --samfile string     Samfile to read. If none is specified, will read from stdin (default "stdin")
  -t, --threads int        Number of threads to use (default 1)

Use "gofasta sam [command] --help" for more information about a command.
2.24-r1122
5.10.0
The query file is:/usr/local/lib/python3.7/site-packages/pangolin/data/reference.fasta
Looking in /usr/local/lib/python3.7/site-packages/pangoLEARN/data for data files...

Data files found
Trained model:  /usr/local/lib/python3.7/site-packages/pangoLEARN/data/decisionTree_v1.joblib
Header file:    /usr/local/lib/python3.7/site-packages/pangoLEARN/data/decisionTreeHeaders_v1.joblib
Lineages csv:   /usr/local/lib/python3.7/site-packages/pangoLEARN/data/lineages.metadata.csv
loading model 01/11/2022, 02:07:00
processing block of 1 sequences 01/11/2022, 02:07:01
complete 01/11/2022, 02:07:02
Output file written to: /nextstrain/build/lineage_report.csv
output:
taxon,lineage,probability,pangoLEARN_version,status,note
outgroup_A,A,1.0,2021-04-01,passed_qc,
```