### PR TITLE
Add nextclade CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,11 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/
         -o /usr/local/bin/nextalign \
  && chmod a+rx /usr/local/bin/nextalign
 
+# Add Nextclade
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+        -o /usr/local/bin/nextclade \
+ && chmod +x nextclade
+
 # Ensure all container users can execute these programs
 RUN chmod a+rX /usr/local/bin/* /usr/local/libexec/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,7 +165,7 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/
 # Add Nextclade
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
         -o /usr/local/bin/nextclade \
- && chmod +x nextclade
+ && chmod +x /usr/local/bin/nextclade
 
 # Ensure all container users can execute these programs
 RUN chmod a+rX /usr/local/bin/* /usr/local/libexec/*


### PR DESCRIPTION
### Description of proposed changes    
This adds Nextclade to nextstrain-base docker image in support of some of the work that @sidneymbell is doing in ncov.

### Related issue(s)  
  https://github.com/nextstrain/ncov/issues/811

### Testing
I've rebuilt the image and the nextclade CLI works in a container launched from it.
```
% ./devel/build
 => exporting to image                                                                                           0.0s
 => => exporting layers                                                                                          0.0s
 => => writing image sha256:dba5d6d91ca4a9625d7ed08c1a66c2efcbb59f3a77a19d903bf5e9907c892def                     0.0s
 => => naming to docker.io/nextstrain/base                                                                       0.0s

% docker run docker.io/nextstrain/base nextclade --help
Viral genome alignment, mutation calling, clade assignment, quality checks and phylogenetic placement.

Usage: nextclade [OPTIONS] [SUBCOMMAND]

Options:
  -h,--help                   Print this help message and exit
```
