### PR TITLE
Install a patched version of pango-designation to fix ncov-ingest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN pip install git+https://github.com/cov-lineages/pangolin.git@v3.1.17
 RUN pip install git+https://github.com/cov-lineages/pangoLEARN.git@2021-12-06
 RUN pip install git+https://github.com/cov-lineages/scorpio.git@v0.3.16
 RUN pip install git+https://github.com/cov-lineages/constellations.git@v0.1.1
-RUN pip install git+https://github.com/cov-lineages/pango-designation.git@v1.2.123
+RUN pip install git+https://github.com/cov-lineages/pango-designation.git@19d9a537b9
 
 # Install Node deps, build Auspice, and link it into the global search path.  A
 # fresh install is only ~40 seconds, so we're not worrying about caching these


### PR DESCRIPTION
### Description of proposed changes    
The pango-designation library [had a packaging bug](https://github.com/cov-lineages/pango-designation/issues/415) that was causing some ncov-ingest tools to break when they ran inside the latest ncov base image. They've since patched the bug, and this PR updates pango-designation to use the current tip of the master branch (pending a new official release)


### Testing

**Before:**

```
% ./devel/build
% docker run -ti --rm=true docker.io/nextstrain/base bash
# apt-get install -y git && pip install regex
# git clone --depth 1 https://github.com/nextstrain/ncov-ingest /ncov-ingest
Cloning into '/ncov-ingest'...
# /ncov-ingest/bin/transform-gisaid
Traceback (most recent call last):
  File "/ncov-ingest/bin/transform-gisaid", line 12, in <module>
    from utils.transform import (
ModuleNotFoundError: No module named 'utils.transform'
```

**After:**

```
% ./devel/build
% docker run -ti --rm=true docker.io/nextstrain/base bash
# apt-get install -y git && pip install regex
# git clone --depth 1 https://github.com/nextstrain/ncov-ingest /ncov-ingest
Cloning into '/ncov-ingest'...
# /ncov-ingest/bin/transform-gisaid
usage: transform-gisaid [-h] [--annotations ANNOTATIONS]
                        [--accessions ACCESSIONS]
                        [--geo-location-rules GEO_LOCATION_RULES]
                        [--output-metadata OUTPUT_METADATA]
                        [--output-fasta OUTPUT_FASTA]
                        [--output-additional-info OUTPUT_ADDITIONAL_INFO]
                        [--sorted-fasta] [--output-unix-newline]
                        gisaid_data
transform-gisaid: error: the following arguments are required: gisaid_data
```



<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
