### PR TITLE
Add Google Cloud Storage Python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,10 @@ RUN pip3 install awscli==1.18.195
 # Install our own CLI so builds can do things like `nextstrain deploy`
 RUN pip3 install nextstrain-cli==2.0.0.post1
 
-# Install Snakemake
+# Install Snakemake and related optional dependencies.
 RUN pip3 install snakemake==5.10.0
+# Google Cloud Storage package is required for Snakemake to fetch remote files
+# from Google Storage URIs.
 RUN pip3 install google-cloud-storage==2.1.0
 
 # Add Nextstrain components

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN pip3 install nextstrain-cli==2.0.0.post1
 
 # Install Snakemake
 RUN pip3 install snakemake==5.10.0
+RUN pip3 install google-cloud-storage==2.1.0
 
 # Add Nextstrain components
 


### PR DESCRIPTION
### Description of proposed changes    

Adds Python package for Google Cloud Storage. This package is required for Snakemake to access remote files storage on Google Cloud Storage, for example when fetching remote files stored on GS from a Terra workflow job.

When this package is not installed, Snakemake will produce the following error:

```
Building DAG of jobs...
InputFunctionException in line 60 of /nextstrain/build/workflow/snakemake_rules/main_workflow.smk:
WorkflowError: The Python 3 package 'google-cloud-sdk' needs to be installed to use GS remote() file functionality. No module named 'google'
Wildcards:
origin=example_data
```

When the package is installed and credentials are not configured to access the GS data, Snakemake produces the following error:

```
DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://cloud.google.com/docs/authentication/getting-started
```

### Testing

 - [x] Tested locally by running a build that referenced files stored in my personal GS account, recreating the errors shown above, and then confirming that the image with this PR's changes fixes the errors.
 - [x] Tested on Terra by referencing the image created for this branch (`nextstrain/base:branch-add-google-cloud-storage`)