### PR TITLE
Install Augur from the latest stable version tag instead of the "release" branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        jq \
         libgmp-dev \
         libpng-dev \
         nodejs \
@@ -76,14 +77,14 @@ RUN pip3 install google-cloud-storage==2.1.0
 # docker build --build-arg CACHE_DATE="$(date)"
 ARG CACHE_DATE
 
-# Add download helper
-COPY devel/download-repo /devel/
+# Add helpers for build
+COPY devel/download-repo devel/latest-augur-release-tag /devel/
 
 # Fauna
 RUN /devel/download-repo https://github.com/nextstrain/fauna master /nextstrain/fauna
 
 # Augur
-RUN /devel/download-repo https://github.com/nextstrain/augur release /nextstrain/augur
+RUN /devel/download-repo https://github.com/nextstrain/augur "$(/devel/latest-augur-release-tag)" /nextstrain/augur
 
 # Auspice
 RUN /devel/download-repo https://github.com/nextstrain/auspice release /nextstrain/auspice

--- a/devel/latest-augur-release-tag
+++ b/devel/latest-augur-release-tag
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Outputs the Git tag for the latest stable release of Augur, supplanting the
+# old "release" branch which no longer exists.
+#
+# By convention/process we make Git tags for each version released to PyPI, so
+# query PyPI's index for the latest stable version and emit that as-is.
+#
+set -euo pipefail
+
+curl -fsSL https://pypi.org/pypi/nextstrain-augur/json | jq -r .info.version


### PR DESCRIPTION
The "release" branch was recently removed.¹  Instead, use the Git tag
for the latest stable version released to PyPI.

There's a larger discussion to be had about if it makes any sense any
more for Augur to be installed from Git instead of PyPI (and
correspondingly, Auspice from NPM), but that's for another time.

¹ https://github.com/nextstrain/augur/pull/913
