### PR TITLE
Update IQ-TREE to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN make FastTreeDblMP
 
 # IQ-TREE
 WORKDIR /build/IQ-TREE
-RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.1.2/iqtree-2.1.2-Linux.tar.gz \
+RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.2.0/iqtree-2.2.0-Linux.tar.gz \
   | tar xzvpf - --strip-components=1
 RUN mv bin/iqtree2 bin/iqtree
 


### PR DESCRIPTION
Requested by @trvrb ([in Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1654121759566409)) after noting 2.1.2's age (October 2020) and some
oddly-resolved phylogenies pointed out by @corneliusroemer.

### Testing
- [x] CI passes?
- [ ] ncov trial run looks ok?