### PR TITLE
ci: Disable pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   run:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description of proposed changes

The PR trigger is unnecessary since all it does is pull/build, which is already done in the checks run by the `push` trigger.

Also, instead of conditioning on `pull_request` trigger, conditioning on the repository being the nextstrain repo will ensure the push trigger runs successfully since fork PRs are not expected to have access to nextstrain-bot Docker credentials.

### Related issue(s)

_N/A_

### Testing

~See CI run on fork.~ Not ready yet.

### TODO

- [ ] get fork checks to show up here