### PR TITLE
Use buildx create+build

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -19,19 +19,37 @@ export GIT_REVISION=$(git describe --tags --abbrev=40 --always --dirty || true)
 # Calling `docker run nextstrain/base` will still only pull down the small base
 # image rather than pulling down the larger nextstrain/base-builder image.
 
-docker build \
+platform=linux/amd64
+
+# `buildx create` is necessary to use a driver that supports multi-platform
+# images.
+builder=nextstrain-builder
+
+if ! docker buildx inspect "$builder" &>/dev/null; then
+    docker buildx create --name "$builder" --driver docker-container
+fi
+
+docker buildx build \
+    --builder "$builder" \
+    --platform $platform \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
     --cache-from nextstrain/base-builder \
     --cache-from nextstrain/base \
+    --cache-to type=inline \
     --tag nextstrain/base-builder \
+    --load \
     --target builder \
     .
 
-docker build \
+docker buildx build \
+    --builder "$builder" \
+    --platform $platform \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
     --cache-from nextstrain/base-builder \
     --cache-from nextstrain/base \
+    --cache-to type=inline \
     --tag nextstrain/base \
+    --load \
     .

--- a/devel/tag
+++ b/devel/tag
@@ -2,6 +2,7 @@
 #
 # Assign the given additional tags to the nextstrain/base:latest and
 # nextstrain/base-builder:latest images.
+# Errors if a tagged image has already been pushed.
 #
 set -euo pipefail
 
@@ -10,7 +11,15 @@ if [[ $# -eq 0 ]]; then
     exit 1
 fi
 
+BASE_IMAGE="nextstrain/base"
+BASE_BUILDER_IMAGE="nextstrain/base-builder"
+
 for tag in "$@"; do
-    docker tag nextstrain/base-builder:{latest,$tag}
-    docker tag nextstrain/base:{latest,$tag}
+    docker tag $BASE_BUILDER_IMAGE:{latest,$tag}
+    docker tag $BASE_IMAGE:{latest,$tag}
 done
+
+if [[ $(docker image inspect --format "{{.RepoDigests}}" $BASE_IMAGE:$tag) != '[]' || $(docker image inspect --format "{{.RepoDigests}}" $BASE_BUILDER_IMAGE:$tag) != '[]' ]]; then
+    echo "At least one of the tagged images has already been pushed. This can happen if the newly built image is not available in the local registry." >&2
+    exit 1
+fi


### PR DESCRIPTION
### Description of proposed changes

This makes it easier to support multi-platform builds in the future, and
explicitly sets the currently used platform (linux/amd64).

Motivated by https://github.com/nextstrain/docker-base/pull/46#pullrequestreview-1005012188, but using `docker buildx create` in the script instead of `setup-buildx-action`.

### Related issue(s)

- Supersedes/closes #46
    - closes #48
- Preparing for #35
- Closes #70

### Testing

See checks.