### PR TITLE
Support building multi-platform images and add `linux/arm64`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,14 @@ jobs:
       tag: ${{ env.TAG }}
 
   test:
+    name: test (${{ matrix.platform }})
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
 
     - uses: docker/login-action@v1
@@ -60,11 +66,18 @@ jobs:
       with:
         python-version: ~3
 
+    # The ubuntu-latest runner is linux/amd64 so anything else will
+    # run with emulation, which is still better than nothing.
+    - if: matrix.platform != 'linux/amd64'
+      uses: docker/setup-qemu-action@v2
+
     - name: Run zika-tutorial
       run: |
         git clone https://github.com/nextstrain/zika-tutorial
         pip install nextstrain-cli
         nextstrain build --image ghcr.io/nextstrain/base:${{ needs.build.outputs.tag }} zika-tutorial -F
+      env:
+        DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
   push-branch:
     if: startsWith(needs.build.outputs.tag, 'branch-') && github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       # and hyphens.
       run: echo "TAG=branch-${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}" | tee -a $GITHUB_ENV
 
+    - uses: docker/setup-qemu-action@v2
+
     # GITHUB_TOKEN is unreliable¹ so use a token from nextstrain-bot.
     # ¹ https://github.com/docker/build-push-action/issues/463#issuecomment-939394233
     - uses: docker/login-action@v1
@@ -38,7 +40,7 @@ jobs:
         username: nextstrain-bot
         password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
 
-    - run: ./devel/build -p linux/amd64 -r ghcr.io -t $TAG
+    - run: ./devel/build -p linux/amd64,linux/arm64 -r ghcr.io -t $TAG
 
     outputs:
       tag: ${{ env.TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         username: nextstrain-bot
         password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
 
-    - run: ./devel/build -r ghcr.io -t $TAG
+    - run: ./devel/build -p linux/amd64 -r ghcr.io -t $TAG
 
     outputs:
       tag: ${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,16 +183,12 @@ COPY builder-scripts/ /builder-scripts/
 
 # Download Nextalign v2
 # Set default Nextalign version to 2
-# NOTE: Running this program requires support for emulation on the Docker host
-# if the processor architecture is not amd64.
-RUN curl -fsSL -o /final/bin/nextalign2 https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-x86_64-unknown-linux-gnu \
+RUN curl -fsSL -o /final/bin/nextalign2 https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-$(/builder-scripts/target-triple) \
  && ln -sv nextalign2 /final/bin/nextalign
 
 # Download Nextclade v2
 # Set default Nextclade version to 2
-# NOTE: Running this program requires support for emulation on the Docker host
-# if the processor architecture is not amd64.
-RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu \
+RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-$(/builder-scripts/target-triple) \
  && ln -sv nextclade2 /final/bin/nextclade
 
 # Fauna

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,27 @@ RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-
 
 # 3. Install programs via pip
 
+# Build cvxopt on linux/arm64
+# cvxopt, an Augur dependency, does not have pre-built binaries for linux/arm64.
+#
+# First, add system deps for building¹:
+# - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
+# - libsuitesparse-dev: Contains SuiteSparse.
+#
+# Then, "install" (build) separately since the process requires a special
+# environment variable².
+#
+# ¹ https://cvxopt.org/install/#building-and-installing-from-source
+# ² https://github.com/cvxopt/cvxopt/issues/125#issuecomment-407396491
+RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
+      apt-get update && apt-get install -y --no-install-recommends \
+          libopenblas-dev \
+          libsuitesparse-dev \
+   && CVXOPT_SUITESPARSE_INC_DIR=/usr/include/suitesparse \
+      pip3 install cvxopt \
+      ; \
+    fi
+
 # Install envdir, which is used by pathogen builds
 RUN pip3 install envdir==1.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN curl -fsSL https://github.com/vcftools/vcftools/releases/download/v0.1.16/vc
 # Download MAFFT
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Instructions: https://mafft.cbrc.jp/alignment/software/installation_without_root.html
 WORKDIR /download/mafft
 RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
   | tar xzvpf - --no-same-owner --strip-components=2 mafft-linux64/mafftdir/ \
@@ -98,6 +99,7 @@ RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
 # Download IQ-TREE
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Instructions: http://www.iqtree.org/doc/Compilation-Guide
 WORKDIR /download/IQ-TREE
 RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.1.2/iqtree-2.1.2-Linux.tar.gz \
   | tar xzvpf - --no-same-owner --strip-components=1 \
@@ -106,16 +108,19 @@ RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.1.2/iqtree
 # Download Nextalign v1
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Example: https://github.com/nextstrain/nextclade/blob/1.11.0/.circleci/config.yml#L183-L223
 RUN curl -fsSL -o /final/bin/nextalign1 https://github.com/nextstrain/nextclade/releases/download/1.11.0/nextalign-Linux-x86_64
 
 # Download Nextclade v1
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Example: https://github.com/nextstrain/nextclade/blob/1.11.0/.circleci/config.yml#L183-L223
 RUN curl -fsSL -o /final/bin/nextclade1 https://github.com/nextstrain/nextclade/releases/download/1.11.0/nextclade-Linux-x86_64
 
 # Download tsv-utils
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Instructions: https://github.com/eBay/tsv-utils/tree/v2.2.0#build-from-source-files
 RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/download/v2.2.0/tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz \
  && tar -x --no-same-owner -v -C /final/bin -z --strip-components 2 --wildcards -f tsv-utils.tar.gz "*/bin/*" \
  && rm -f tsv-utils.tar.gz
@@ -129,12 +134,14 @@ RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit
 # Download gofasta (for ncov/Pangolin)
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Instructions: https://github.com/virus-evolution/gofasta/tree/v0.0.6#installation
 RUN curl -fsSL https://github.com/virus-evolution/gofasta/releases/download/v0.0.6/gofasta-linux-amd64 \
   -o /final/bin/gofasta
 
 # Download minimap2 (for ncov/Pangolin)
 # NOTE: Running this program requires support for emulation on the Docker host
 # if the processor architecture is not amd64.
+# TODO: Build from source to avoid emulation. Instructions: https://github.com/lh3/minimap2/tree/v2.24#install
 RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
   | tar xjvpf - --no-same-owner --strip-components=1 -C /final/bin minimap2-2.24_x64-linux/minimap2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,14 +121,10 @@ RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/downl
  && rm -f tsv-utils.tar.gz
 
 # Download csvtk
-# NOTE: Running this program requires support for emulation on the Docker host
-# if the processor architecture is not amd64.
-RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_linux_amd64.tar.gz | tar xz --no-same-owner -C /final/bin
+RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download seqkit
-# NOTE: Running this program requires support for emulation on the Docker host
-# if the processor architecture is not amd64.
-RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_linux_amd64.tar.gz | tar xz --no-same-owner -C /final/bin
+RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download gofasta (for ncov/Pangolin)
 # NOTE: Running this program requires support for emulation on the Docker host

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install a specific Node.js version
 # https://github.com/nodesource/distributions/blob/0d81da75/README.md#installation-instructions
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
  && apt-get update && apt-get install -y nodejs
 
 # Used for platform-specific instructions
@@ -297,7 +297,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install a specific Node.js version
 # https://github.com/nodesource/distributions/blob/0d81da75/README.md#installation-instructions
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
  && apt-get update && apt-get install -y nodejs
 
 # Configure bash for interactive usage

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
  && apt-get update && apt-get install -y nodejs
 
+# Used for platform-specific instructions
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
 # Add dependencies. All should be pinned to specific versions, except
 # Nextstrain-maintained software.
 # This includes pathogen-specific workflow dependencies. Since we only maintain a

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,8 +223,8 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release
 RUN pip3 install evofr
 
 # Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
-RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/datasets
-RUN curl -fsSL -o /final/bin/dataformat https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/dataformat
+RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/datasets
+RUN curl -fsSL -o /final/bin/dataformat https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/dataformat
 
 # ———————————————————————————————————————————————————————————————————— #
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,15 @@ RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       ; \
     fi
 
+# Install jaxlib on linux/arm64
+# jaxlib, an evofr dependency, does not have official pre-built binaries for
+# linux/arm64. A GitHub user has provided them in a fork repo.
+# https://github.com/google/jax/issues/7097#issuecomment-1110730040
+RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
+      pip3 install https://github.com/yoziru/jax/releases/download/jaxlib-v0.3.25/jaxlib-0.3.25-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl \
+      ; \
+    fi
+
 # Install envdir, which is used by pathogen builds
 RUN pip3 install envdir==1.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,14 @@ RUN mkdir -p /final/bin /final/share /final/libexec
 # 1. Build programs from source
 
 # Build RAxML
-# AVX should be widely-supported enough
+# linux/arm64 does not support -mavx and -msse3 compilation flags which are used in the official repository.
+# Make these changes in a fork for now: https://github.com/nextstrain/standard-RAxML/tree/simde
+# TODO: Use the official repository if this PR is ever merged: https://github.com/stamatak/standard-RAxML/pull/50
 WORKDIR /build/RAxML
-RUN curl -fsSL https://api.github.com/repos/stamatak/standard-RAxML/tarball/v8.2.12 \
+RUN curl -fsSL https://api.github.com/repos/nextstrain/standard-RAxML/tarball/4621552064304a219ff03810f5f0d91e1063b68f \
   | tar xzvpf - --no-same-owner --strip-components=1 \
- && make -f Makefile.AVX.PTHREADS.gcc \
- && cp -p raxmlHPC-PTHREADS-AVX /final/bin
+  && make -f Makefile.AVX.PTHREADS.gcc \
+  && cp -p raxmlHPC-PTHREADS-AVX /final/bin
 
 # Build FastTree
 WORKDIR /build/FastTree

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN curl -fsSL https://github.com/vcftools/vcftools/releases/download/v0.1.16/vc
 # 2. Download pre-built programs
 
 # Download MAFFT
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 WORKDIR /download/mafft
 RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
   | tar xzvpf - --no-same-owner --strip-components=2 mafft-linux64/mafftdir/ \
@@ -94,33 +96,49 @@ RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
  && cp -p libexec/* /final/libexec
 
 # Download IQ-TREE
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 WORKDIR /download/IQ-TREE
 RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.1.2/iqtree-2.1.2-Linux.tar.gz \
   | tar xzvpf - --no-same-owner --strip-components=1 \
  && mv bin/iqtree2 /final/bin/iqtree
 
 # Download Nextalign v1
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL -o /final/bin/nextalign1 https://github.com/nextstrain/nextclade/releases/download/1.11.0/nextalign-Linux-x86_64
 
 # Download Nextclade v1
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL -o /final/bin/nextclade1 https://github.com/nextstrain/nextclade/releases/download/1.11.0/nextclade-Linux-x86_64
 
 # Download tsv-utils
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/download/v2.2.0/tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz \
  && tar -x --no-same-owner -v -C /final/bin -z --strip-components 2 --wildcards -f tsv-utils.tar.gz "*/bin/*" \
  && rm -f tsv-utils.tar.gz
 
 # Download csvtk
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_linux_amd64.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download seqkit
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_linux_amd64.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download gofasta (for ncov/Pangolin)
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL https://github.com/virus-evolution/gofasta/releases/download/v0.0.6/gofasta-linux-amd64 \
   -o /final/bin/gofasta
 
 # Download minimap2 (for ncov/Pangolin)
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-2.24_x64-linux.tar.bz2 \
   | tar xjvpf - --no-same-owner --strip-components=1 -C /final/bin minimap2-2.24_x64-linux/minimap2
 
@@ -169,11 +187,15 @@ COPY builder-scripts/ /builder-scripts/
 
 # Download Nextalign v2
 # Set default Nextalign version to 2
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL -o /final/bin/nextalign2 https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-x86_64-unknown-linux-gnu \
  && ln -sv nextalign2 /final/bin/nextalign
 
 # Download Nextclade v2
 # Set default Nextclade version to 2
+# NOTE: Running this program requires support for emulation on the Docker host
+# if the processor architecture is not amd64.
 RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu \
  && ln -sv nextclade2 /final/bin/nextclade
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ To add a software program to `nextstrain/base`, follow steps in this order:
 2. Check if it is available via PyPI. You can search on [PyPI's
    website](https://pypi.org/search/). If available, add an install command to
    the section labeled with `Install programs via pip`.
-3. Check if a pre-built binary is available on the software's website (e.g.
+3. Check if a pre-built binary for the `linux/amd64` platform (name contains
+   `linux` and `amd64`/`x86_64`) is available on the software's website (e.g.
    GitHub release assets). If available, add a download command to the section
    labeled with `Download pre-built programs`.
 4. The last resort is to build from source. Look for instructions on the

--- a/README.md
+++ b/README.md
@@ -103,9 +103,14 @@ To add a software program to `nextstrain/base`, follow steps in this order:
    `linux` and `amd64`/`x86_64`) is available on the software's website (e.g.
    GitHub release assets). If available, add a download command to the section
    labeled with `Download pre-built programs`.
+    - If a pre-built binary supporting `linux/arm64` (name contains `linux` and
+      `arm64`/`aarch64`) is also available, that should be used conditionally on
+      `ARG`s `TARGETPLATFORM` or `TARGETOS`+`TARGETARCH` in the Dockerfile. See
+      existing usage of those arguments for examples.
 4. The last resort is to build from source. Look for instructions on the
    software's website. Add a build command to the section labeled with `Build
-   programs from source`.
+   programs from source`. Note that this can require platform-specific
+   instructions.
 
 If possible, pin the software to a specific version. Otherwise, add the
 download/install/build command to the section labeled with `Add unpinned

--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ To build this image locally,
     ./devel/build
     ```
 
-    By default, this tags the image with `latest` and pushes to
+    By default, this builds for a single platform `linux/amd64`, tags the image with `latest`, and pushes to
     `localhost:5000`. See instructions at the top of the script for additional
     options.
+
+    If the target platform is different from the build platform, set up emulation before running `./devel/build`. This can be achieved using [`tonistiigi/binfmt`](https://github.com/tonistiigi/binfmt). For example, to set up emulation for `linux/arm64`, run:
+
+    ```
+    docker run --privileged --rm tonistiigi/binfmt --install arm64
+    ```
 
 On each subsequent change during your development iterations, you can run just
 the `./devel/build` command again.

--- a/builder-scripts/target-triple
+++ b/builder-scripts/target-triple
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Get the target triple from a Docker target platform.
+#
+# The Docker target platform is provided by the TARGETPLATFORM variable¹.
+# ¹ https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+#
+set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+    TARGETPLATFORM="$1"
+fi
+
+case $TARGETPLATFORM in
+    "linux/amd64")
+        echo "x86_64-unknown-linux-gnu"
+        ;;
+    "linux/arm64")
+        echo "aarch64-unknown-linux-gnu"
+        ;;
+    *)
+        echo "No target triple mapping for $TARGETPLATFORM." 1>&2
+        exit 1
+        ;;
+esac

--- a/devel/build
+++ b/devel/build
@@ -14,15 +14,17 @@
 set -euo pipefail
 
 # Set default values.
+platform=linux/amd64
 registry=localhost:5000
 tag=latest
 
 # Read command-line arguments.
-while getopts "r:t:" opt; do
+while getopts "p:r:t:" opt; do
     case "$opt" in
+        p) platform="$OPTARG";;
         r) registry="$OPTARG";;
         t) tag="$OPTARG";;
-        *) echo "Usage: $0 [-r <registry>] [-t <tag>]" 1>&2; exit 1;;
+        *) echo "Usage: $0 [-p <platform>] [-r <registry>] [-t <tag>]" 1>&2; exit 1;;
     esac
 done
 
@@ -35,8 +37,6 @@ export GIT_REVISION=$(git describe --tags --abbrev=40 --always --dirty || true)
 #
 # Calling `docker run nextstrain/base` will still only pull down the small base
 # image rather than pulling down the larger nextstrain/base-builder image.
-
-platform=linux/amd64
 
 # `buildx create` is necessary to use a driver that supports multi-platform
 # images.


### PR DESCRIPTION
### Description of proposed changes

Currently, the Docker images are built for `linux/amd64` only. These changes build the Docker images for both `linux/amd64` and `linux/arm64`.

This will substantially improve the performance of the Docker runtime for Apple silicon users, as it no longer needs to use slow Intel architecture emulation. A major drawback is the increased build time since building the `linux/arm64` image on a `linux/amd64` GitHub Actions runner requires emulation. However, IMO the benefit to users outweighs the increased build-time on our end, which can be improved in the future.

Cross-compilation (#98) is a major build-time improvement on top of this PR to be considered separately.

### Changes made outside of PR

- [x] Added `docker/setup-qemu-action@*` to allowed third party actions under @nextstrain

### Related issue(s)

- Resolves #35
- Supercedes/closes #48

### Testing

- [x] Checks pass
- [x] Multi-arch images for the PR branch are available on Docker Hub for [nextstrain/base](https://hub.docker.com/r/nextstrain/base/tags) and [nextstrain/base-builder](https://hub.docker.com/r/nextstrain/base-builder/tags)
- [x] Run zika-tutorial on linux/arm64 image "natively" using M1 Mac (54s run time)
- [x] Run zika-tutorial on linux/amd64 image natively using Linux on GitHub Codespace (50s run time)
- [x] Run ncov-tutorial on linux/arm64 image "natively" using M1 Mac (2m 23s run time)
- [x] Run ncov-tutorial on linux/amd64 image natively using Linux on GitHub Codespace (3m 6s run time)
- [x] ~test linux/arm64 image without emulation (all my M1 Macs have Rosetta enabled, and [it isn't easy to disable](https://developer.apple.com/forums/thread/669486?answerId=681889022#681889022).~ Not doing this since this feature is targeted towards other Apple silicon users which should also have Rosetta enabled.

### Summary of comment threads

- Local registry? ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r955533198))
- Self-hosted runners to avoid emulation slowdowns? ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r961056450))
- Cross-compilation? ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r986331019))
- Emulation of pre-built binaries ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r971207015))
- Compiling/runtime issues in `arm64` build
    - RAxML ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r961092320))
    - matplotlib ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r956218475))
    - Nextclade ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r971105452))
    - cvxopt ([ref](https://github.com/nextstrain/docker-base/pull/50#discussion_r981811688))