### PR TITLE
Add tsv-utils, csvtk, and seqkit to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,17 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/
         -o /usr/local/bin/nextclade \
  && chmod +x /usr/local/bin/nextclade
 
+# Add tsv-utils
+RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/download/v2.2.0/tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz \
+ && tar -x -v -C /usr/local/bin -z --strip-components 2 --wildcards -f tsv-utils.tar.gz "*/bin/*" \
+ && rm -f tsv-utils.tar.gz
+
+# Add csvtk
+RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+
+# Add seqkit
+RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+
 # Ensure all container users can execute these programs
 RUN chmod a+rX /usr/local/bin/* /usr/local/libexec/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,14 +173,14 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/
 
 # Add tsv-utils
 RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/download/v2.2.0/tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz \
- && tar -x -v -C /usr/local/bin -z --strip-components 2 --wildcards -f tsv-utils.tar.gz "*/bin/*" \
+ && tar -x --no-same-owner -v -C /usr/local/bin -z --strip-components 2 --wildcards -f tsv-utils.tar.gz "*/bin/*" \
  && rm -f tsv-utils.tar.gz
 
 # Add csvtk
-RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_linux_amd64.tar.gz | tar xz --no-same-owner -C /usr/local/bin
 
 # Add seqkit
-RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_linux_amd64.tar.gz | tar xz -C /usr/local/bin
+RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_linux_amd64.tar.gz | tar xz --no-same-owner -C /usr/local/bin
 
 # Ensure all container users can execute these programs
 RUN chmod a+rX /usr/local/bin/* /usr/local/libexec/*


### PR DESCRIPTION
### Description of proposed changes

Adds regularly used utilities to the base image, so they can be used in our workflows.

I opted to use prebuilt binaries here instead of setting up dev environments for D and Go, to support these different tools. If building from source is seen as a valuable step, we'll need to expand this PR a bit to include those environments.

You can test this image locally by starting Docker and running:

```
nextstrain shell --image nextstrain/base:branch-add-csv-tsv-seq-utils .
```

Then try any of these new utilities.