### PR TITLE
Install less(1) so there's a reasonable pager for `nextstrain shell`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         gzip \
+        less \
         nodejs \
         perl \
         ruby \


### PR DESCRIPTION
Resolves <https://github.com/nextstrain/docker-base/issues/72>.

### Testing
- [x] CI passes
- [ ] Less is present in branch image build