### PR TITLE
Check all tags before pushing

### DIFF
--- a/devel/push
+++ b/devel/push
@@ -5,7 +5,7 @@
 # By default this publishes the "latest" tag, but you can provide other tags in
 # addition to or instead of "latest".
 #
-# Errors if a tagged image has already been pushed.
+# Errors if any of the tagged images have already been pushed.
 #
 set -euo pipefail
 
@@ -18,12 +18,13 @@ BASE_IMAGE="nextstrain/base"
 BASE_BUILDER_IMAGE="nextstrain/base-builder"
 
 for tag in "$@"; do
-
     if [[ $(docker image inspect --format "{{.RepoDigests}}" $BASE_IMAGE:$tag) != '[]' || $(docker image inspect --format "{{.RepoDigests}}" $BASE_BUILDER_IMAGE:$tag) != '[]' ]]; then
-        echo "At least one of the tagged images has already been pushed. This can happen if the newly built image is not available in the local registry." >&2
+        echo "At least one of $BASE_IMAGE:$tag and $BASE_BUILDER_IMAGE:$tag has already been pushed. This can happen if the newly built image is not available in the local registry." >&2
         exit 1
     fi
+done
 
+for tag in "$@"; do
     docker push $BASE_BUILDER_IMAGE:$tag
     docker push $BASE_IMAGE:$tag
 done


### PR DESCRIPTION
### Description of proposed changes

This check was placed incorrectly in 7d4daa92af7269240a349bca5c56589f27563bee.

Two tags can point to the same image and if one of them is pushed first,
the other will error even though both were "new" at the start of the
script.

### Related issue(s)

- Addresses issue in https://github.com/nextstrain/docker-base/pull/78#discussion_r953171715

### Testing

- [x] CI passes
- [ ] Post-merge: check that `build-…` and `latest` tags are pushed successfully and only after tests pass