### PR TITLE
Remove usage of augur full dependency list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN pip3 install --requirement=/nextstrain/fauna/requirements.txt
 # Augur is an editable install so we can overlay the augur version in the image
 # with --volume=.../augur:/nextstrain/augur and still have it globally
 # accessible and importable.
-RUN pip3 install --editable "/nextstrain/augur[full]"
+RUN pip3 install --editable "/nextstrain/augur"
 
 # Install pathogen-specific workflow dependencies. Since we only maintain a
 # single Docker image to support all pathogen workflows, some pathogen-specific


### PR DESCRIPTION
### Description of proposed changes

It has been removed in https://github.com/nextstrain/augur/pull/1035.

### Testing

- [x] Checks pass