### PR TITLE
Configure the prompt using bashrc instead of a profile.d snippet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,8 +148,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zip unzip \
         zstd
 
-# Configure the prompt for interactive usage
-COPY prompt.sh /etc/profile.d/
+# Configure bash for interactive usage
+COPY bashrc /etc/bash.bashrc
 
 # Add custom built programs
 ENV MAFFT_BINARIES=/usr/local/libexec

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,8 @@
+# Note that this file is overridden by newer versions of `nextstrain shell` and
+# so it provides only a fallback prompt for users of older CLI versions or
+# direct image users (e.g. `docker run …`).
+reset="\[\e[0m\]"
+bold="\[\e[1m\]"
+magenta="\[\e[35m\]"
+PS1="${bold}nextstrain:${magenta}\w${reset} ${bold}\$ ${reset}"
+unset reset bold magenta

--- a/prompt.sh
+++ b/prompt.sh
@@ -1,4 +1,5 @@
-RESET="\[\e[0m\]"
-BOLD="\[\e[1m\]"
-MAGENTA="\[\e[35m\]"
-PS1="${BOLD}nextstrain:${MAGENTA}\w${RESET} ${BOLD}\$ ${RESET}"
+reset="\[\e[0m\]"
+bold="\[\e[1m\]"
+magenta="\[\e[35m\]"
+PS1="${bold}nextstrain:${magenta}\w${reset} ${bold}\$ ${reset}"
+unset reset bold magenta

--- a/prompt.sh
+++ b/prompt.sh
@@ -1,5 +1,0 @@
-reset="\[\e[0m\]"
-bold="\[\e[1m\]"
-magenta="\[\e[35m\]"
-PS1="${bold}nextstrain:${magenta}\w${reset} ${bold}\$ ${reset}"
-unset reset bold magenta


### PR DESCRIPTION
The upshot of this is that any interactive Bash session gets the prompt,
not just a login session.  It also makes overriding the file in newer
`nextstrain shell` versions a bit less custom, since /etc/bash.bashrc is
the standard Debian/Ubuntu system bashrc path.

### Testing
- [x] Manual testing with `nextstrain shell` and `docker run …`
- [x] CI passes