### PR TITLE
Non-root user, trois

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         nodejs \
         perl \
         ruby \
+        util-linux \
         wget \
         xz-utils \
         zip unzip \
@@ -259,6 +260,7 @@ RUN useradd nextstrain \
 
 # The host should bind mount the pathogen build dir into /nextstrain/build.
 WORKDIR /nextstrain/build
+RUN chown nextstrain:nextstrain /nextstrain/build
 
 ENTRYPOINT ["/sbin/entrypoint"]
 

--- a/entrypoint
+++ b/entrypoint
@@ -17,6 +17,11 @@ if [[ $# -eq 0 ]]; then
         the source of the \`nextstrain\` command for examples.
     "
 else
-    # Otherwise, exec into whatever command is provided.
-    exec "$@"
+    # Otherwise, exec into whatever command is provided…
+    if [[ "$(id -u):$(id -g)" == 0:0 ]]; then
+        # …switching to nextstrain:nextstrain first if we're root.
+        exec setpriv --reuid nextstrain --regid nextstrain --init-groups "$@"
+    else
+        exec "$@"
+    fi
 fi


### PR DESCRIPTION
Switch to non-root user (nextstrain) in entrypoint exec chain

Restores default use of a non-root user even for ad-hoc image uses without getting in the way (like USER does) of downstream images inheriting from us (see previous commit).

setpriv is part of util-linux, which is installed by default but is also installed explicitly in case that changes.  It is an exec-chaining program explicitly designed for modifying privs normally retained across an exec boundary.

A chown ensures that /nextstrain/build is writable by the nextstrain user.  This doesn't matter for the local Docker runtime (e.g. via `nextstrain build --docker`) because we mount over the container's /nextstrain/build with the build directory from the host (and run as the host user's uid/gid).  But for the AWS Batch runtime we _don't_ mount over /nextstrain/build: the entrypoint extracts a build archive into it at job start.  Since this happens _after_ the setpriv, /nextstrain/build needs to be writable by the nextstrain user.

### Related issue(s)
Related to #83, #85

### Testing
- [x] CI
- [x] Manual testing locally
- [x] Test ncov-ingest image build against it
- [x] Test local pathogen build against it
- [x] Test AWS Batch pathogen build against it