### PR TITLE
Improve `--cache-from` caching

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -47,8 +47,8 @@ docker buildx build \
     --platform $platform \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
-    --cache-from $BASE_BUILDER_IMAGE \
-    --cache-from $BASE_IMAGE \
+    --cache-from $BASE_BUILDER_IMAGE:latest \
+    --cache-from $BASE_IMAGE:latest \
     --cache-to type=inline \
     --tag $BASE_BUILDER_IMAGE:$tag \
     --load \
@@ -60,8 +60,8 @@ docker buildx build \
     --platform $platform \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
-    --cache-from $BASE_BUILDER_IMAGE \
-    --cache-from $BASE_IMAGE \
+    --cache-from $BASE_BUILDER_IMAGE:latest \
+    --cache-from $BASE_IMAGE:latest \
     --cache-to type=inline \
     --tag $BASE_IMAGE:$tag \
     --load \

--- a/devel/build
+++ b/devel/build
@@ -48,7 +48,9 @@ docker buildx build \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
     --cache-from $BASE_BUILDER_IMAGE:latest \
+    --cache-from $BASE_BUILDER_IMAGE:$tag \
     --cache-from $BASE_IMAGE:latest \
+    --cache-from $BASE_IMAGE:$tag \
     --cache-to type=inline \
     --tag $BASE_BUILDER_IMAGE:$tag \
     --load \
@@ -61,7 +63,9 @@ docker buildx build \
     --build-arg CACHE_DATE \
     --build-arg GIT_REVISION \
     --cache-from $BASE_BUILDER_IMAGE:latest \
+    --cache-from $BASE_BUILDER_IMAGE:$tag \
     --cache-from $BASE_IMAGE:latest \
+    --cache-from $BASE_IMAGE:$tag \
     --cache-to type=inline \
     --tag $BASE_IMAGE:$tag \
     --load \


### PR DESCRIPTION
### Description of proposed changes

Import caches from both `latest` and `$tag` (if available) on registry for caching.

Reference: https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from

### Related issue(s)

- Closes #57

### Testing

- [x] Checks pass