### PR TITLE
Remove final image cache source from builder image

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -49,8 +49,6 @@ docker buildx build \
     --build-arg GIT_REVISION \
     --cache-from $BASE_BUILDER_IMAGE:latest \
     --cache-from $BASE_BUILDER_IMAGE:$tag \
-    --cache-from $BASE_IMAGE:latest \
-    --cache-from $BASE_IMAGE:$tag \
     --cache-to type=inline \
     --tag $BASE_BUILDER_IMAGE:$tag \
     --load \


### PR DESCRIPTION
### Description of proposed changes

The builder image does not need to look for layers in the final image.

### Related issue(s)

- #57
    Note that I don't expect any significant performance improvement from this change, but at the least this reduces unnecessary cache retrieval.

### Testing

- [x] Checks pass