### PR TITLE
Use cross-compilation where possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,19 @@ RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/
 # Linking is used so we can overlay the auspice version in the image with
 # --volume=.../auspice:/nextstrain/auspice and still have it globally accessible
 # and importable.
+#
+# Versions of NPM might differ in platform between where Auspice is installed
+# and where it is used (the final image). This does not matter since Auspice
+# (and its runtime dependencies at the time of writing) are not
+# platform-specific.
+# This may change in the future, which would call for cross-platform
+# installation using npm_config_arch (if using node-gyp¹ or prebuild-install²)
+# or npm_config_target_arch (if using node-pre-gyp³⁴).
+#
+# ¹ https://github.com/nodejs/node-gyp#environment-variables
+# ² https://github.com/prebuild/prebuild-install#help
+# ³ https://github.com/mapbox/node-pre-gyp#options
+# ⁴ https://github.com/mapbox/node-pre-gyp/blob/v1.0.10/lib/node-pre-gyp.js#L186
 WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
  && npm update && npm install && npm run build && npm link

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,10 +94,12 @@ RUN curl -fsSL https://api.github.com/repos/nextstrain/FastTree/tarball/df4212c8
  && cp -p FastTreeDblMP /final/bin
 
 # Build vcftools
+# Some unreleased changes are necessary to allow Autoconf to work with cross-compilation¹.
+# ¹ https://github.com/vcftools/vcftools/commit/1cab5204eb0ce01664178bafd0ad6104525709d1
 WORKDIR /build/vcftools
-RUN curl -fsSL https://github.com/vcftools/vcftools/releases/download/v0.1.16/vcftools-0.1.16.tar.gz \
-  | tar xzvpf - --no-same-owner --strip-components=2 \
- && ./configure --prefix=$PWD/built \
+RUN curl -fsSL https://api.github.com/repos/vcftools/vcftools/tarball/1cab5204eb0ce01664178bafd0ad6104525709d1 \
+  | tar xzvpf - --no-same-owner --strip-components=1 \
+ && ./autogen.sh && ./configure --prefix=$PWD/built \
       --build=$(TARGETPLATFORM= xx-clang --print-target-triple) \
       --host=$(xx-clang --print-target-triple) \
  && make && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ COPY --from=xx / /
 # pkg-config: for building VCFtools; may be used by package managers to build from source
 # zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 # nodejs: for installing Auspice
+# clang: for compiling C/C++ projects; may be used by package managers to build from source
 RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
         automake \
+        clang \
         ca-certificates \
         curl \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=xx / /
 # git: used in builder-scripts/download-repo
 # make: used for building from Makefiles (search for usage); may be used by package managers to build from source
 # pkg-config: for building VCFtools; may be used by package managers to build from source
-# zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 # nodejs: for installing Auspice
 # clang: for compiling C/C++ projects; may be used by package managers to build from source
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -38,8 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         make \
-        pkg-config \
-        zlib1g-dev
+        pkg-config
 
 # Install a specific Node.js version
 # https://github.com/nodesource/distributions/blob/0d81da75/README.md#installation-instructions
@@ -54,10 +52,12 @@ ARG TARGETARCH
 # Install packages that generate binaries for the target architecture.
 # https://github.com/tonistiigi/xx#building-on-debian
 # binutils, gcc, libc6-dev: for compiling C/C++ programs (TODO: verify)
+# zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 RUN xx-apt-get install -y \
   binutils \
   gcc \
-  libc6-dev
+  libc6-dev \
+  zlib1g-dev
 
 # Add dependencies. All should be pinned to specific versions, except
 # Nextstrain-maintained software.

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,13 +74,13 @@ RUN mkdir -p /final/bin /final/share /final/libexec
 # 1. Build programs from source
 
 # Build RAxML
-# linux/arm64 does not support -mavx and -msse3 compilation flags which are used in the official repository.
-# Make these changes in a fork for now: https://github.com/nextstrain/standard-RAxML/tree/simde
+# Some changes are necessary to allow the Makefile to work with cross-compilation.
+# Make these changes in a fork for now: https://github.com/nextstrain/standard-RAxML/tree/fix-cross-compile
 # TODO: Use the official repository if this PR is ever merged: https://github.com/stamatak/standard-RAxML/pull/50
 WORKDIR /build/RAxML
-RUN curl -fsSL https://api.github.com/repos/nextstrain/standard-RAxML/tarball/4621552064304a219ff03810f5f0d91e1063b68f \
+RUN curl -fsSL https://api.github.com/repos/nextstrain/standard-RAxML/tarball/4868de62a62be8901259807cfea26f336c2ca477 \
   | tar xzvpf - --no-same-owner --strip-components=1 \
-  && make -f Makefile.AVX.PTHREADS.gcc \
+  && CC=xx-clang make -f Makefile.AVX.PTHREADS.gcc \
   && cp -p raxmlHPC-PTHREADS-AVX /final/bin
 
 # Build FastTree

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,20 +22,20 @@ COPY --from=xx / /
 
 # Add system deps for building
 # autoconf, automake: for building VCFtools; may be used by package managers to build from source
-# build-essential: contains gcc, g++, make, etc. for building various tools; may be used by package managers to build from source
 # ca-certificates: for secure HTTPS connections
 # curl: for downloading source files
 # git: used in builder-scripts/download-repo
+# make: used for building from Makefiles (search for usage); may be used by package managers to build from source
 # pkg-config: for building VCFtools; may be used by package managers to build from source
 # zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 # nodejs: for installing Auspice
 RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
         automake \
-        build-essential \
         ca-certificates \
         curl \
         git \
+        make \
         pkg-config \
         zlib1g-dev
 
@@ -298,6 +298,8 @@ RUN pip3 install phylo-treetime
 # CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64.
 #
 # First, add system deps for building¹:
+# - gcc: C compiler.
+# - libc6-dev: C libraries and header files.
 # - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
 # - SuiteSparse: Download the source code so it can be built alongside CVXOPT.
 #
@@ -309,6 +311,8 @@ RUN pip3 install phylo-treetime
 WORKDIR /cvxopt
 RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       apt-get update && apt-get install -y --no-install-recommends \
+          gcc \
+          libc6-dev \
           libopenblas-dev \
    && mkdir SuiteSparse \
    && curl -fsSL https://api.github.com/repos/DrTimothyAldenDavis/SuiteSparse/tarball/v5.8.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,9 +219,11 @@ ARG TARGETARCH
 # Add system deps for building
 # curl, jq: used in builder-scripts/latest-augur-release-tag
 # git: for git pip installs
+# gcc: for building datrie (for Snakemake)
 # libsqlite3-dev, zlib1g-dev: for building pyfastx (for Augur)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
+        gcc \
         git \
         jq \
         libsqlite3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,8 @@ WORKDIR /build/vcftools
 RUN curl -fsSL https://github.com/vcftools/vcftools/releases/download/v0.1.16/vcftools-0.1.16.tar.gz \
   | tar xzvpf - --no-same-owner --strip-components=2 \
  && ./configure --prefix=$PWD/built \
+      --build=$(TARGETPLATFORM= xx-clang --print-target-triple) \
+      --host=$(xx-clang --print-target-triple) \
  && make && make install \
  && cp -rp built/bin/*    /final/bin \
  && cp -rp built/share/*  /final/share

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,33 @@
 # This is a multi-stage image build.
 #
-# We first create a "builder" image and then create our final image by copying
-# things from the builder image.  The point is to avoid bloating the final
-# image with tools only needed during the image build.
+# We first create two builder images (builder-build-platform,
+# builder-target-platform). Then we create our final image by copying things
+# from the builder images. The point is to avoid bloating the final image with
+# tools only needed during the image build.
 
-# First build the temporary image.
-FROM python:3.10-slim-bullseye AS builder
+# Setup: pull cross-compilation tools.
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+
+# ———————————————————————————————————————————————————————————————————— #
+
+# Define a builder stage that runs on the build platform.
+# Even if the target platform is different, instructions will run natively for
+# faster compilation.
+FROM --platform=$BUILDPLATFORM debian:11-slim AS builder-build-platform
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
+
+# Copy cross-compilation tools.
+COPY --from=xx / /
 
 # Add system deps for building
 # autoconf, automake: for building VCFtools; may be used by package managers to build from source
 # build-essential: contains gcc, g++, make, etc. for building various tools; may be used by package managers to build from source
 # ca-certificates: for secure HTTPS connections
 # curl: for downloading source files
-# git: for git pip installs
-# jq: used in builder-scripts/latest-augur-release-tag
-# libsqlite3-dev: for building pyfastx (for Augur)
+# git: used in builder-scripts/download-repo
 # pkg-config: for building VCFtools; may be used by package managers to build from source
-# zlib1g-dev: for building VCFtools and pyfastx; may be used by package managers to build from source
+# zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 # nodejs: for installing Auspice
 RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
@@ -27,8 +36,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
-        jq \
-        libsqlite3-dev \
         pkg-config \
         zlib1g-dev
 
@@ -41,6 +48,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+
+# Install packages that generate binaries for the target architecture.
+# https://github.com/tonistiigi/xx#building-on-debian
+# binutils, gcc, libc6-dev: for compiling C/C++ programs (TODO: verify)
+RUN xx-apt-get install -y \
+  binutils \
+  gcc \
+  libc6-dev
 
 # Add dependencies. All should be pinned to specific versions, except
 # Nextstrain-maintained software.
@@ -145,7 +160,75 @@ RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-
   | tar xjvpf - --no-same-owner --strip-components=1 -C /final/bin minimap2-2.24_x64-linux/minimap2
 
 
-# 3. Install programs via pip
+# 3. Add unpinned programs
+
+# Allow caching to be avoided from here on out in this stage by calling
+# docker build --build-arg CACHE_DATE="$(date)"
+# NOTE: All versioned software added below should be checked in
+# devel/validate-platforms.
+ARG CACHE_DATE
+
+# Add helper scripts
+COPY builder-scripts/ /builder-scripts/
+
+# Nextclade/Nextalign v2 are downloaded directly but using the latest version,
+# so they belong after CACHE_DATE (unlike Nextclade/Nextalign v1).
+
+# Download Nextalign v2
+# Set default Nextalign version to 2
+RUN curl -fsSL -o /final/bin/nextalign2 https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-$(/builder-scripts/target-triple) \
+ && ln -sv nextalign2 /final/bin/nextalign
+
+# Download Nextclade v2
+# Set default Nextclade version to 2
+RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-$(/builder-scripts/target-triple) \
+ && ln -sv nextclade2 /final/bin/nextclade
+
+# Auspice
+# Install Node deps, build Auspice, and link it into the global search path.  A
+# fresh install is only ~40 seconds, so we're not worrying about caching these
+# as we did the Python deps.  Building auspice means we can run it without
+# hot-reloading, which is time-consuming and generally unnecessary in the
+# container image.  Linking is equivalent to an editable Python install and
+# used for the same reasons described above.
+WORKDIR /nextstrain/auspice
+RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
+ && npm update && npm install && npm run build && npm link
+
+# Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
+RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/datasets
+RUN curl -fsSL -o /final/bin/dataformat https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/dataformat
+
+# ———————————————————————————————————————————————————————————————————— #
+
+# Define a builder stage that runs on the target platform.
+# If the target platform is different from the build platform, instructions will
+# run under emulation which can be slower.
+# This is in place for Python programs which are not easy to install for a
+# different target platform¹.
+# ¹ https://github.com/pypa/pip/issues/5453
+FROM --platform=$TARGETPLATFORM python:3.10-slim-bullseye AS builder-target-platform
+
+SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
+
+# Used for platform-specific instructions
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+# Add system deps for building
+# curl, jq: used in builder-scripts/latest-augur-release-tag
+# git: for git pip installs
+# libsqlite3-dev, zlib1g-dev: for building pyfastx (for Augur)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        jq \
+        libsqlite3-dev \
+        zlib1g-dev
+
+
+# 1. Install programs via pip
 
 # Install jaxlib on linux/arm64
 # jaxlib, an evofr dependency, does not have official pre-built binaries for
@@ -184,32 +267,20 @@ RUN pip3 install pysam==0.19.1
 # Install pango_aliasor (for forecasts-ncov)
 RUN pip3 install pango_aliasor==0.3.0
 
-# 4. Add unpinned programs
 
-# Allow caching to be avoided from here on out by calling
+# 2. Add unpinned programs
+
+# Allow caching to be avoided from here on out in this stage by calling
 # docker build --build-arg CACHE_DATE="$(date)"
 # NOTE: All versioned software added below should be checked in
 # devel/validate-platforms.
 ARG CACHE_DATE
 
-# Install our own CLI so builds can do things like `nextstrain deploy`
-RUN pip3 install nextstrain-cli
-
 # Add helper scripts
 COPY builder-scripts/ /builder-scripts/
 
-# Nextclade/Nextalign v2 are downloaded directly but using the latest version,
-# so they belong after CACHE_DATE (unlike Nextclade/Nextalign v1).
-
-# Download Nextalign v2
-# Set default Nextalign version to 2
-RUN curl -fsSL -o /final/bin/nextalign2 https://github.com/nextstrain/nextclade/releases/latest/download/nextalign-$(/builder-scripts/target-triple) \
- && ln -sv nextalign2 /final/bin/nextalign
-
-# Download Nextclade v2
-# Set default Nextclade version to 2
-RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-$(/builder-scripts/target-triple) \
- && ln -sv nextclade2 /final/bin/nextclade
+# Install our own CLI so builds can do things like `nextstrain deploy`
+RUN pip3 install nextstrain-cli
 
 # Fauna
 WORKDIR /nextstrain/fauna
@@ -252,23 +323,8 @@ WORKDIR /nextstrain/augur
 RUN /builder-scripts/download-repo https://github.com/nextstrain/augur "$(/builder-scripts/latest-augur-release-tag)" . \
  && pip3 install --editable .
 
-# Auspice
-# Install Node deps, build Auspice, and link it into the global search path.  A
-# fresh install is only ~40 seconds, so we're not worrying about caching these
-# as we did the Python deps.  Building auspice means we can run it without
-# hot-reloading, which is time-consuming and generally unnecessary in the
-# container image.  Linking is equivalent to an editable Python install and
-# used for the same reasons described above.
-WORKDIR /nextstrain/auspice
-RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
- && npm update && npm install && npm run build && npm link
-
 # Add evofr for forecasting
 RUN pip3 install evofr
-
-# Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
-RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/datasets
-RUN curl -fsSL -o /final/bin/dataformat https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/dataformat
 
 # ———————————————————————————————————————————————————————————————————— #
 
@@ -333,9 +389,9 @@ RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
 COPY bashrc /etc/bash.bashrc
 
 # Copy binaries
-COPY --from=builder /final/bin/ /usr/local/bin/
-COPY --from=builder /final/share/ /usr/local/share/
-COPY --from=builder /final/libexec/ /usr/local/libexec/
+COPY --from=builder-build-platform  /final/bin/     /usr/local/bin/
+COPY --from=builder-build-platform  /final/share/   /usr/local/share/
+COPY --from=builder-build-platform  /final/libexec/ /usr/local/libexec/
 
 # Set MAFFT_BINARIES explicitly for MAFFT
 ENV MAFFT_BINARIES=/usr/local/libexec
@@ -344,7 +400,7 @@ ENV MAFFT_BINARIES=/usr/local/libexec
 RUN chmod a+rx /usr/local/bin/* /usr/local/libexec/*
 
 # Add installed Python libs
-COPY --from=builder /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
+COPY --from=builder-target-platform /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
 
 # Add installed Python scripts that we need.
 #
@@ -355,7 +411,7 @@ COPY --from=builder /usr/local/lib/python3.10/site-packages/ /usr/local/lib/pyth
 # as the set of things to copy) in the future if the maintenance burden becomes
 # troublesome or excessive.
 #   -trs, 15 June 2018
-COPY --from=builder \
+COPY --from=builder-target-platform \
     /usr/local/bin/augur \
     /usr/local/bin/aws \
     /usr/local/bin/envdir \
@@ -368,7 +424,7 @@ COPY --from=builder \
     /usr/local/bin/
 
 # Add installed Node libs
-COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
+COPY --from=builder-build-platform /usr/lib/node_modules/ /usr/lib/node_modules/
 
 # Add globally linked Auspice script.
 #
@@ -379,7 +435,8 @@ COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
 RUN ln -sv /usr/lib/node_modules/auspice/auspice.js /usr/local/bin/auspice
 
 # Add Nextstrain components
-COPY --from=builder /nextstrain /nextstrain
+COPY --from=builder-build-platform  /nextstrain /nextstrain
+COPY --from=builder-target-platform /nextstrain /nextstrain
 
 # Add our entrypoints and helpers
 COPY entrypoint entrypoint-aws-batch drop-privs create-envd delete-envd /sbin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,12 @@ ARG TARGETARCH
 # Install packages that generate binaries for the target architecture.
 # https://github.com/tonistiigi/xx#building-on-debian
 # binutils, gcc, libc6-dev: for compiling C/C++ programs (TODO: verify)
+# g++: for building VCFtools; may be used by package managers to build from source
 # zlib1g-dev: for building VCFtools; may be used by package managers to build from source
 RUN xx-apt-get install -y \
   binutils \
   gcc \
+  g++ \
   libc6-dev \
   zlib1g-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,9 +85,9 @@ RUN curl -fsSL https://api.github.com/repos/nextstrain/standard-RAxML/tarball/48
 
 # Build FastTree
 WORKDIR /build/FastTree
-RUN curl -fsSL https://api.github.com/repos/tsibley/FastTree/tarball/50c5b098ea085b46de30bfc29da5e3f113353e6f \
+RUN curl -fsSL https://api.github.com/repos/nextstrain/FastTree/tarball/df4212c8c9991e7e0d432e42d53c21cd8408a181 \
   | tar xzvpf - --no-same-owner --strip-components=1 \
- && make FastTreeDblMP \
+ && CC=$(xx-info)-gcc make FastTreeDblMP \
  && cp -p FastTreeDblMP /final/bin
 
 # Build vcftools

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
         make \
-        pkg-config
+        pkg-config \
+        dpkg-dev
 
 # Install a specific Node.js version
 # https://github.com/nodesource/distributions/blob/0d81da75/README.md#installation-instructions

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,12 +194,11 @@ RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/
  && ln -sv nextclade2 /final/bin/nextclade
 
 # Auspice
-# Install Node deps, build Auspice, and link it into the global search path.  A
-# fresh install is only ~40 seconds, so we're not worrying about caching these
-# as we did the Python deps.  Building auspice means we can run it without
-# hot-reloading, which is time-consuming and generally unnecessary in the
-# container image.  Linking is equivalent to an editable Python install and
-# used for the same reasons described above.
+# Building auspice means we can run it without hot-reloading, which is
+# time-consuming and generally unnecessary in the container image.
+# Linking is used so we can overlay the auspice version in the image with
+# --volume=.../auspice:/nextstrain/auspice and still have it globally accessible
+# and importable.
 WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
  && npm update && npm install && npm run build && npm link

--- a/README.md
+++ b/README.md
@@ -109,9 +109,8 @@ To push images you've built locally to Docker Hub, you can run:
 
     ./devel/copy-images -t <tag>
 
-This will copy the `nextstrain/base:<tag>` and `nextstrain/base-builder:<tag>`
-images from the local Docker registry to Docker Hub. See instructions at the top
-of the script for more options.
+This will copy the Nextstrain images from the local Docker registry to Docker
+Hub. See instructions at the top of the script for more options.
 
 ### Adding a new software program
 
@@ -136,11 +135,15 @@ To add a software program to `nextstrain/base`, follow steps in this order:
 4. The last resort is to build from source. Look for instructions on the
    software's website. Add a build command to the section labeled with `Build
    programs from source`. Note that this can require platform-specific
-   instructions.
+   instructions. You should utilize cross-compilation tool available in the
+   builder stage that runs on the build platform.
 
 If possible, pin the software to a specific version. Otherwise, add the
 download/install/build command to the section labeled with `Add unpinned
 programs` to ensure the latest version is included in every Docker image build.
+
+If possible, add the program to the builder stage that runs on the build
+platform to avoid slowness that may arise from emulation.
 
 ### Best practices
 

--- a/devel/build
+++ b/devel/build
@@ -53,20 +53,36 @@ if ! docker buildx inspect "$builder" &>/dev/null; then
     docker buildx create --name "$builder" --driver docker-container --driver-opt network=host
 fi
 
-BUILDER_IMAGE=nextstrain/base-builder
+BUILDER_BUILD_PLATFORM_IMAGE=nextstrain/base-builder-build-platform
+BUILDER_TARGET_PLATFORM_IMAGE=nextstrain/base-builder-target-platform
 FINAL_IMAGE=nextstrain/base
 
 docker buildx build \
-    --target builder \
+    --target builder-build-platform \
     --builder "$builder" \
     --platform "$platform" \
     --build-arg CACHE_DATE \
-    --cache-from "$BUILDER_IMAGE:latest" \
-    --cache-from "$BUILDER_IMAGE:$tag" \
-    --cache-from "$registry/$BUILDER_IMAGE:latest" \
-    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
+    --cache-from "$BUILDER_BUILD_PLATFORM_IMAGE:latest" \
+    --cache-from "$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
     --cache-to type=inline \
-    --tag "$registry/$BUILDER_IMAGE:$tag" \
+    --tag "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+    --push \
+    --provenance false \
+    .
+
+docker buildx build \
+    --target builder-target-platform \
+    --builder "$builder" \
+    --platform "$platform" \
+    --build-arg CACHE_DATE \
+    --cache-from "$BUILDER_TARGET_PLATFORM_IMAGE:latest" \
+    --cache-from "$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
+    --cache-to type=inline \
+    --tag "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
     --push \
     --provenance false \
     .
@@ -77,12 +93,16 @@ docker buildx build \
     --platform "$platform" \
     --build-arg GIT_REVISION \
     --build-arg CACHE_DATE \
-    --cache-from "$BUILDER_IMAGE:latest" \
-    --cache-from "$BUILDER_IMAGE:$tag" \
+    --cache-from "$BUILDER_BUILD_PLATFORM_IMAGE:latest" \
+    --cache-from "$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+    --cache-from "$BUILDER_TARGET_PLATFORM_IMAGE:latest" \
+    --cache-from "$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
     --cache-from "$FINAL_IMAGE:latest" \
     --cache-from "$FINAL_IMAGE:$tag" \
-    --cache-from "$registry/$BUILDER_IMAGE:latest" \
-    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
     --cache-from "$registry/$FINAL_IMAGE:latest" \
     --cache-from "$registry/$FINAL_IMAGE:$tag" \
     --cache-to type=inline \

--- a/devel/copy-images
+++ b/devel/copy-images
@@ -33,7 +33,8 @@ if [[ "$tag" = "" ]]; then
     exit 1
 fi
 
-BUILDER_IMAGE=nextstrain/base-builder
+BUILDER_BUILD_PLATFORM_IMAGE=nextstrain/base-builder-build-platform
+BUILDER_TARGET_PLATFORM_IMAGE=nextstrain/base-builder-target-platform
 FINAL_IMAGE=nextstrain/base
 
 
@@ -77,26 +78,36 @@ copy-image() {
 
 # Copy $tag between registries.
 
+echo "Copying $registry_in/$BUILDER_BUILD_PLATFORM_IMAGE:$tag to $registry_out/$BUILDER_BUILD_PLATFORM_IMAGE:$tag."
+copy-image \
+    "$registry_in/$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+    "$registry_out/$BUILDER_BUILD_PLATFORM_IMAGE:$tag"
+
+echo "Copying $registry_in/$BUILDER_TARGET_PLATFORM_IMAGE:$tag to $registry_out/$BUILDER_TARGET_PLATFORM_IMAGE:$tag."
+copy-image \
+    "$registry_in/$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
+    "$registry_out/$BUILDER_TARGET_PLATFORM_IMAGE:$tag"
+
 echo "Copying $registry_in/$FINAL_IMAGE:$tag to $registry_out/$FINAL_IMAGE:$tag."
 copy-image \
     "$registry_in/$FINAL_IMAGE:$tag" \
     "$registry_out/$FINAL_IMAGE:$tag"
 
-echo "Copying $registry_in/$BUILDER_IMAGE:$tag to $registry_out/$BUILDER_IMAGE:$tag."
-copy-image \
-    "$registry_in/$BUILDER_IMAGE:$tag" \
-    "$registry_out/$BUILDER_IMAGE:$tag"
-
 if [[ "$push_latest" = true ]]; then
     # Copy $tag to latest.
+
+    echo "Copying $registry_in/$BUILDER_BUILD_PLATFORM_IMAGE:$tag to $registry_out/$BUILDER_BUILD_PLATFORM_IMAGE:latest."
+    copy-image \
+        "$registry_in/$BUILDER_BUILD_PLATFORM_IMAGE:$tag" \
+        "$registry_out/$BUILDER_BUILD_PLATFORM_IMAGE:latest"
+
+    echo "Copying $registry_in/$BUILDER_TARGET_PLATFORM_IMAGE:$tag to $registry_out/$BUILDER_TARGET_PLATFORM_IMAGE:latest."
+    copy-image \
+        "$registry_in/$BUILDER_TARGET_PLATFORM_IMAGE:$tag" \
+        "$registry_out/$BUILDER_TARGET_PLATFORM_IMAGE:latest"
 
     echo "Copying $registry_in/$FINAL_IMAGE:$tag to $registry_out/$FINAL_IMAGE:latest."
     copy-image \
         "$registry_in/$FINAL_IMAGE:$tag" \
         "$registry_out/$FINAL_IMAGE:latest"
-
-    echo "Copying $registry_in/$BUILDER_IMAGE:$tag to $registry_out/$BUILDER_IMAGE:latest."
-    copy-image \
-        "$registry_in/$BUILDER_IMAGE:$tag" \
-        "$registry_out/$BUILDER_IMAGE:latest"
 fi

--- a/devel/delete-from-ghcr.js
+++ b/devel/delete-from-ghcr.js
@@ -9,7 +9,11 @@
 
 module.exports = async ({fetch, octokit, tag, token}) => {
   org = 'nextstrain';
-  packages = ['base', 'base-builder'];
+  packages = [
+    'base',
+    'base-builder-build-platform',
+    'base-builder-target-platform',
+  ];
 
   // Try all packages before terminating with any errors.
   let errorEncountered = false;

--- a/devel/pull-from-registry
+++ b/devel/pull-from-registry
@@ -17,8 +17,10 @@ while getopts "r:t:" opt; do
     esac
 done
 
-BUILDER_IMAGE=nextstrain/base-builder
+BUILDER_BUILD_PLATFORM_IMAGE=nextstrain/base-builder-build-platform
+BUILDER_TARGET_PLATFORM_IMAGE=nextstrain/base-builder-target-platform
 FINAL_IMAGE=nextstrain/base
 
-docker pull "$registry/$BUILDER_IMAGE:$tag"
+docker pull "$registry/$BUILDER_BUILD_PLATFORM_IMAGE:$tag"
+docker pull "$registry/$BUILDER_TARGET_PLATFORM_IMAGE:$tag"
 docker pull "$registry/$FINAL_IMAGE:$tag"


### PR DESCRIPTION
### Description of proposed changes

As [noted](https://github.com/nextstrain/docker-base/pull/50#discussion_r986331019) in the PR that introduced multi-platform images, [cross-compilation](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/) can substantially improve multi-platform build time.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- #50

### Notable discussions

- Naming of Dockerfile stages ([ref](https://github.com/nextstrain/docker-base/pull/98#discussion_r1133001444))

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Verify that binaries on the `arm64` image variant are native to the platform. Evidence:

    ```
    % docker pull --platform linux/arm64 nextstrain/base:branch-victorlin-arm64-cross-compilation
    % docker run -it --entrypoint /bin/bash nextstrain/base:branch-victorlin-arm64-cross-compilation

    nextstrain:~/build $ apt-get update && apt-get install file -y

    nextstrain:~/build $ file /usr/local/bin/raxmlHPC-PTHREADS-AVX
    /usr/local/bin/raxmlHPC-PTHREADS-AVX: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=a06a245ef61d80661f3c3fd584a4a2002a4568f3, for GNU/Linux 3.7.0, not stripped

    nextstrain:~/build $ file /usr/local/bin/FastTreeDblMP
    /usr/local/bin/FastTreeDblMP: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=4c9df1efc0725502472822181484324f8aa3be59, for GNU/Linux 3.7.0, not stripped

    nextstrain:~/build $ file /usr/local/bin/vcftools
    /usr/local/bin/vcftools: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=e9b3149b8288e62c72d82f420d423076f22cf490, for GNU/Linux 3.7.0, with debug_info, not stripped

    nextstrain:~/build $ node -e "console.log(process.arch)"
    arm64
    ```

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->