### PR TITLE
Upgrade python & debian to the latest released version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # image with tools only needed during the image build.
 
 # First build the temporary image.
-FROM python:3.10.8-slim-buster AS builder
+FROM python:3.10-slim-buster AS builder
 
 # Execute subsequent RUN statements with bash for handy modern shell features.
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release
 # ———————————————————————————————————————————————————————————————————— #
 
 # Now build the final image.
-FROM python:3.7-slim-buster AS final
+FROM python:3.10-slim-buster AS final
 
 # Add system runtime deps
 # bzip2, gzip, xz-utils, zip, unzip, zstd: install compression tools
@@ -243,7 +243,7 @@ ENV MAFFT_BINARIES=/usr/local/libexec
 RUN chmod a+rx /usr/local/bin/* /usr/local/libexec/*
 
 # Add installed Python libs
-COPY --from=builder /usr/local/lib/python3.7/site-packages/ /usr/local/lib/python3.7/site-packages/
+COPY --from=builder /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
 
 # Add installed Python scripts that we need.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # image with tools only needed during the image build.
 
 # First build the temporary image.
-FROM python:3.7-slim-buster AS builder
+FROM python:3.10.8-slim-buster AS builder
 
 # Execute subsequent RUN statements with bash for handy modern shell features.
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # image with tools only needed during the image build.
 
 # First build the temporary image.
-FROM python:3.10-slim-buster AS builder
+FROM python:3.10-slim-bullseye AS builder
 
 # Execute subsequent RUN statements with bash for handy modern shell features.
 SHELL ["/bin/bash", "-c"]
@@ -196,7 +196,7 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release
 # ———————————————————————————————————————————————————————————————————— #
 
 # Now build the final image.
-FROM python:3.10-slim-buster AS final
+FROM python:3.10-slim-bullseye AS final
 
 # Add system runtime deps
 # bzip2, gzip, xz-utils, zip, unzip, zstd: install compression tools


### PR DESCRIPTION
### Description of proposed changes

Upgrade Python and Debian to the latest released version.

Python 3.7 is over four years old at this point. Our team has a variety of python scripts that we run alongside Nextstrain in Docker, and we'd like to be able to take advantage of the improved typing capabilities of Python 3.9+. In addition it upgrades to the latest debian LTS

### Related issue(s)

This supercedes #66 
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
