### PR TITLE
Upgrade Python from 3.7 to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # image with tools only needed during the image build.
 
 # First build the temporary image.
-FROM python:3.7-slim-bullseye AS builder
+FROM python:3.10-slim-bullseye AS builder
 
 # Execute subsequent RUN statements with bash for handy modern shell features.
 SHELL ["/bin/bash", "-c"]
@@ -196,7 +196,7 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release
 # ———————————————————————————————————————————————————————————————————— #
 
 # Now build the final image.
-FROM python:3.7-slim-bullseye AS final
+FROM python:3.10-slim-bullseye AS final
 
 # Add system runtime deps
 # bzip2, gzip, xz-utils, zip, unzip, zstd: install compression tools
@@ -243,7 +243,7 @@ ENV MAFFT_BINARIES=/usr/local/libexec
 RUN chmod a+rx /usr/local/bin/* /usr/local/libexec/*
 
 # Add installed Python libs
-COPY --from=builder /usr/local/lib/python3.7/site-packages/ /usr/local/lib/python3.7/site-packages/
+COPY --from=builder /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
 
 # Add installed Python scripts that we need.
 #


### PR DESCRIPTION
3.7 was chosen in early 2020, when 3.8 was only a few months old.  3.10 is now a year old, and we already use it in other Nextstrain contexts.

The motivation for this came from @jgadling who wanted to take advantage of newer Python typing features in scripts running alongside Nextstrain in this Docker image.

(Change made by @jgadling, commit written by @tsibley.)

(Rework of #100 to squash commits and write a commit message with more rationale.)