### PR TITLE
Add `evofr` for forecasts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,6 +192,9 @@ WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
  && npm update && npm install && npm run build && npm link
 
+# Add evofr for forecasting
+RUN pip3 install evofr
+
 # ———————————————————————————————————————————————————————————————————— #
 
 # Now build the final image.


### PR DESCRIPTION
Creating PR to start some general discussions:

1. Should `evofr` be added to docker-base or should we create a separate forecasts image? 
I've added it here to easily test with the `nextstrain/base:branch-evofr` image, but I'm not sure if we should actually add it to docker-base since it's such a niche tool. We are currently only using `evofr` for [forecasts-ncov](https://github.com/nextstrain/forecasts-ncov), but we will probably expand to other pathogens. It's unclear to me how much it will get used by outside Nextstrain users. 

1. How often should the image get updated? 
Since `evofr` is still in development, would it make sense to add a GH Action to the `evofr` repo to build the image on each push to the main branch?