### PR TITLE
build: Use intermediate registry as a cache source

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -61,6 +61,8 @@ docker buildx build \
     --build-arg GIT_REVISION \
     --cache-from "$BUILDER_IMAGE:latest" \
     --cache-from "$BUILDER_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
     --cache-to type=inline \
     --tag "$registry/$BUILDER_IMAGE:$tag" \
     --push \
@@ -76,6 +78,10 @@ docker buildx build \
     --cache-from "$BUILDER_IMAGE:$tag" \
     --cache-from "$FINAL_IMAGE:latest" \
     --cache-from "$FINAL_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
+    --cache-from "$registry/$FINAL_IMAGE:latest" \
+    --cache-from "$registry/$FINAL_IMAGE:$tag" \
     --cache-to type=inline \
     --tag "$registry/$FINAL_IMAGE:$tag" \
     --push \


### PR DESCRIPTION
### Description of proposed changes

Currently, only images available locally or on the destination registry (Docker Hub) are used for caching. This was fine before the usage of an intermediate directory. Now that built images are no longer available locally, there are two new issues:

1. The final stage does not use the cached builder stage since it is no longer available from cache sources.
2. Local development is slower since the built image layers are not available from cache sources.

Adding the intermediate registry as a cache source fixes these.

### Related issue(s)

- Follow-up to #103

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
