### PR TITLE
Add NCBI Datasets CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,10 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release
 # Add evofr for forecasting
 RUN pip3 install evofr
 
+# Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
+RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/datasets
+RUN curl -fsSL -o /final/bin/dataformat https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/dataformat
+
 # ———————————————————————————————————————————————————————————————————— #
 
 # Now build the final image.


### PR DESCRIPTION
### Description of proposed changes

The NCBI Datasets command line tools will be used to fetch virus packages¹ for various pathogen ingest pipelines.

The `datasets` command fetches the virus packages and the `dataformat` command transforms the nested JSON data structure to flat TSV metadata files.

¹ https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/data-packages/virus-genome/

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
