### PR TITLE
Upgrade pangolin to v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         jq \
         libsqlite3-dev \
         pkg-config \
-        rsync \
         zlib1g-dev
 
 # Install a specific Node.js version

--- a/devel/build
+++ b/devel/build
@@ -51,6 +51,7 @@ if ! docker buildx inspect "$builder" &>/dev/null; then
 fi
 
 BUILDER_IMAGE=nextstrain/base-builder
+USHER_IMAGE=nextstrain/usher-builder
 FINAL_IMAGE=nextstrain/base
 
 docker buildx build \
@@ -69,6 +70,21 @@ docker buildx build \
     .
 
 docker buildx build \
+    --target usher \
+    --builder "$builder" \
+    --platform "$platform" \
+    --build-arg CACHE_DATE \
+    --build-arg GIT_REVISION \
+    --cache-from "$USHER_IMAGE:latest" \
+    --cache-from "$USHER_IMAGE:$tag" \
+    --cache-from "$registry/$USHER_IMAGE:latest" \
+    --cache-from "$registry/$USHER_IMAGE:$tag" \
+    --cache-to type=inline \
+    --tag "$registry/$USHER_IMAGE:$tag" \
+    --push \
+    .
+
+docker buildx build \
     --target final \
     --builder "$builder" \
     --platform "$platform" \
@@ -76,12 +92,16 @@ docker buildx build \
     --build-arg GIT_REVISION \
     --cache-from "$BUILDER_IMAGE:latest" \
     --cache-from "$BUILDER_IMAGE:$tag" \
+    --cache-from "$USHER_IMAGE:latest" \
+    --cache-from "$USHER_IMAGE:$tag" \
     --cache-from "$FINAL_IMAGE:latest" \
     --cache-from "$FINAL_IMAGE:$tag" \
     --cache-from "$registry/$BUILDER_IMAGE:latest" \
     --cache-from "$registry/$BUILDER_IMAGE:$tag" \
     --cache-from "$registry/$FINAL_IMAGE:latest" \
     --cache-from "$registry/$FINAL_IMAGE:$tag" \
+    --cache-from "$registry/$USHER_IMAGE:latest" \
+    --cache-from "$registry/$USHER_IMAGE:$tag" \
     --cache-to type=inline \
     --tag "$registry/$FINAL_IMAGE:$tag" \
     --push \

--- a/devel/start-localhost-registry
+++ b/devel/start-localhost-registry
@@ -13,4 +13,4 @@ NAME=nextstrain-local-registry
 # Docker image that provides the registry service.
 IMAGE=registry:2
 
-docker run -d -p "$PORT":"$PORT" --restart always --name "$NAME" "$IMAGE" > /dev/null
+docker run -d -p $PORT:5000 --restart always --name "$NAME" "$IMAGE" > /dev/null


### PR DESCRIPTION
### Description of proposed changes

Upgrade pangolin (with UShER support) to version 4.1.3

I've done this by creating another intermediate-build image for UShER. The UShER team *is* publishing an image to dockerhub [here](https://registry.hub.docker.com/r/pathogengenomics/usher), but it's based on an OS with different shared-library versions than the one we're using, so it's difficult/impractical to just use the built binaries from the upstream image.

I can easily refactor this to skip adding a third upstream image repository if that's a problem.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

I spot-checked that pangolin works in UShER and scorpio mode in the final image.

#### UShER mode:
```
nextstrain:/tmp $ pangolin test_genome.fasta
****
Pangolin running in usher mode.
****
<content omitted>

Using UShER as inference engine.
****
Output file written to: /tmp/lineage_report.csv
```
#### PangoLEARN mode
```
nextstrain:/tmp $ pangolin --analysis-mode fast test_genome.fasta
****
Pangolin running in pangolearn mode.
****
Warning: pangoLEARN mode may use a significant amount of RAM, be aware that it will not suit every system.
Maximum ambiguity allowed is 0.3.
****
Query file:     /tmp/test_genome.fasta
****
<content omitted>
Processing block of 3 sequences 12/12/2022, 18:03:03
Complete 12/12/2022, 18:03:03
****
Output file written to: /tmp/lineage_report.csv
```

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
