### PR TITLE
Remove redundant Auspice build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/augur "$(/build
 # used for the same reasons described above.
 WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
- && npm update && npm install && npm run build && npm link
+ && npm update && npm install && npm link
 
 # Add evofr for forecasting
 RUN pip3 install evofr


### PR DESCRIPTION
### Description of proposed changes

Auspice has a `prepare` script that runs the `build` script automatically after `npm install`. This means the explicit call to run the `build` script is redundant and can be removed to improve build times.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] `nextstrain view --docker --image nextstrain/base:branch-victorlin-remove-redundant-auspice-build` works

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
