### PR TITLE
Add libgomp1 for running FastTree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -271,6 +271,7 @@ FROM python:3.10-slim-bullseye AS final
 # dos2unix: tsv-utils needs unix line endings
 # jq: may be used by workflows
 # less: for usability in an interactive prompt
+# libgomp1: for running FastTree
 # libsqlite3: for pyfastx (for Augur)
 # perl: for running VCFtools
 # ruby: may be used by workflows
@@ -285,6 +286,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gzip \
         jq \
         less \
+        libgomp1 \
         libsqlite3-0 \
         perl \
         ruby \


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

As far as I can tell from the official software page¹, no dependencies are documented.

However, there are (unofficial?) Linux packages²³ that list libc6 and libgomp1 as dependencies. Adding the latter for now since `augur tree --method fasttree` fails with the error:

    FastTreeDblMP: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory

¹ http://www.microbesonline.org/fasttree/
² https://packages.ubuntu.com/focal/fasttree
³ https://packages.debian.org/sid/science/fasttree


### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Fixes #123

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] `docker run nextstrain/base:branch-victorlin-fix-fasttree FastTreeDblMP -h` shows the help output instead of the error in the original issue.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
