### PR TITLE
CI: Validate images across platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,24 @@ jobs:
       env:
         DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
+  validate-platforms:
+    name: Validate platforms
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: docker/setup-qemu-action@v2
+
+    - uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: nextstrain-bot
+        password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
+
+    - name: Validate final images
+      run: ./devel/validate-platforms -r ghcr.io -t ${{ needs.build.outputs.tag }}
+
   # "Push" (copy) the builder and final images from GitHub Container Registry to
   # Docker Hub, where they will persist. Do this regardless of test results.
   push-branch:
@@ -110,7 +128,7 @@ jobs:
   # Docker Hub, where they will persist. Only do this if tests pass.
   push-build:
     if: startsWith(needs.build.outputs.tag, 'build-')
-    needs: [build, test]
+    needs: [build, test, validate-platforms]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -134,7 +152,7 @@ jobs:
   # Delete the builder and final images from GitHub Container Registry.
   cleanup-registry:
     if: always()
-    needs: [build, test, push-branch, push-build]
+    needs: [build, test, validate-platforms, push-branch, push-build]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,8 @@ RUN pip3 install pysam==0.19.1
 
 # Allow caching to be avoided from here on out by calling
 # docker build --build-arg CACHE_DATE="$(date)"
+# NOTE: All versioned software added below should be checked in
+# devel/validate-platforms.
 ARG CACHE_DATE
 
 # Install our own CLI so builds can do things like `nextstrain deploy`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ variable to a new timestamp first:
 Otherwise, letting the build process use the cached layers will save you time
 during development iterations.
 
+### Validate the images
+
+Before using the images, they should be checked for any inconsistencies.
+
+    ./devel/validate-platforms
+
+The output and exit code will tell you whether validation is successful.
+
 ### Using the images locally
 
 Since the images are pushed directly to the local registry, they are not

--- a/devel/validate-platforms
+++ b/devel/validate-platforms
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Validate different platform builds of the final Nextstrain image.
+#
+set -euo pipefail
+
+# Set default values.
+registry=localhost:5000
+tag=latest
+
+# Read command-line arguments.
+while getopts "r:t:" opt; do
+    case "$opt" in
+        r) registry="$OPTARG";;
+        t) tag="$OPTARG";;
+        *) echo "Usage: $0 [-r <registry>] [-t <tag>]" 1>&2; exit 1;;
+    esac
+done
+
+IMAGE="$registry/nextstrain/base:$tag"
+PLATFORMS=(linux/amd64 linux/arm64)
+
+main() {
+    # Check that every platform image got the same versions of important (e.g.
+    # first-party) software for which we don't pin a specific version (e.g. we
+    # install whatever the latest version is at build time).
+
+    local report_dir
+    report_dir="$(mktemp -dt "$(basename "$0")"-XXXXXX)"
+
+    for platform in "${PLATFORMS[@]}"; do
+        echo "[$platform] Pulling image..."
+        docker pull -q --platform "$platform" "$IMAGE"
+
+        echo "[$platform] Checking that the platform is expected..."
+        check-platform "$platform"
+
+        # Initialize a directory for the report file, ensuring slashes in the
+        # platform name are subdirs.
+        report="$report_dir/$platform"
+        echo "[$platform] Generating report file: $report"
+        mkdir -p "$(dirname "$report")"
+
+        # Create a report file for the platform.
+        # This should include all software below ARG CACHE_DATE in the Dockerfile
+        # in addition to other important software.
+        echo "[$platform] Determining software versions..."
+        docker-run "$platform" bash -c '
+            PS4="\$ "
+            set -x
+
+            nextstrain --version
+            nextalign --version
+            nextclade --version
+            augur --version
+            auspice --version
+            python3 -c "from importlib.metadata import version; print(version(\"evofr\"))"
+            datasets --version
+            dataformat version
+
+            python3 -c "from importlib.metadata import version; print(version(\"phylo-treetime\"))"
+        ' >"$report" 2>&1
+    done
+
+    # Compare contents of the first platform's report file against others.
+    first_report="$report_dir/${PLATFORMS[0]}"
+    echo "The report for ${PLATFORMS[0]} has the following contents:"
+    cat "$first_report"
+
+    echo "Comparing against other platforms..."
+    # NOTE: if running on macOS ≥13, you may need to install GNU diff for the
+    # --from-file option.
+    if cd "$report_dir" && diff --unified=1 --from-file="${PLATFORMS[0]}" "${PLATFORMS[@]:1}"; then
+        echo "Success!  All versions the same." >&2
+    else
+        echo "Failure!" >&2
+        exit 1
+     fi
+}
+
+check-platform() {
+    # Check that the platform is actually what we expect it to be.
+    local platform="$1"
+
+    python_platform_string="$(docker-run "$platform" python -c "import platform; print(platform.platform())")"
+
+    case "$platform" in
+        linux/amd64)
+            if [[ "$python_platform_string" != *"x86_64"* ]]; then
+                echo "Platform $platform not detected." 1>&2; exit 1
+            fi;;
+        linux/arm64)
+            if [[ "$python_platform_string" != *"aarch64"* ]]; then
+                echo "Platform $platform not detected." 1>&2; exit 1
+            fi;;
+        *)
+            echo "Platform $platform not supported." 1>&2; exit 1;;
+    esac
+}
+
+docker-run() {
+    # Run a command under the final Nextstrain image built for a specific
+    # platform.
+    local platform="$1"
+    local command=("${@:2}")
+
+    docker run --rm --platform "$platform" "$IMAGE" "${command[@]}"
+}
+
+main

--- a/devel/validate-platforms
+++ b/devel/validate-platforms
@@ -46,8 +46,10 @@ main() {
         # in addition to other important software.
         echo "[$platform] Determining software versions..."
         docker-run "$platform" bash -c '
-            PS4="\$ "
-            set -x
+            function echo-command {
+                echo "$ $BASH_COMMAND"
+            }
+            trap echo-command DEBUG
 
             nextstrain --version
             nextalign --version
@@ -59,7 +61,7 @@ main() {
             dataformat version
 
             python3 -c "from importlib.metadata import version; print(version(\"phylo-treetime\"))"
-        ' >"$report" 2>&1
+        ' >"$report"
     done
 
     # Compare contents of the first platform's report file against others.


### PR DESCRIPTION
### Description of proposed changes

Start off by checking software in which versions are known to be time-varying.

### Related issue(s)

- Addresses the main point in #128.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

Tested locally:

1. With a tag known to have differing Augur versions.

    <details>

    <summary>
    Commands and output
    </summary>

    ```
    % ./devel/validate-platforms -r docker.io -t build-20230217T192833Z
    [linux/amd64] Pulling image...
    docker.io/nextstrain/base:build-20230217T192833Z
    [linux/amd64] Checking that the platform is expected...
    [linux/amd64] Generating report file: /var/folders/rk/s2p6nv1d13lcf0dynjkvxyl80000gp/T/validate-platforms-XXXXXX.WEPtnBnz/linux/amd64
    [linux/amd64] Determining software versions...
    [linux/arm64] Pulling image...
    docker.io/nextstrain/base:build-20230217T192833Z
    [linux/arm64] Checking that the platform is expected...
    [linux/arm64] Generating report file: /var/folders/rk/s2p6nv1d13lcf0dynjkvxyl80000gp/T/validate-platforms-XXXXXX.WEPtnBnz/linux/arm64
    [linux/arm64] Determining software versions...
    The report for linux/amd64 has the following contents:
    $ nextstrain --version
    nextstrain.cli 6.1.0.post1
    $ nextalign --version
    nextalign 2.11.0
    $ nextclade --version
    nextclade 2.11.0
    $ augur --version
    augur 21.0.0
    $ auspice --version
    2.43.0
    $ python3 -c "from importlib.metadata import version; print(version(\"evofr\"))"
    0.1.16
    $ datasets --version
    datasets version: 14.13.0
    $ dataformat version
    14.13.0
    $ python3 -c "from importlib.metadata import version; print(version(\"phylo-treetime\"))"
    0.9.5
    Comparing against other platforms...
    --- linux/amd64	2023-03-10 12:13:04.000000000 -0800
    +++ linux/arm64	2023-03-10 12:13:11.000000000 -0800
    @@ -7,3 +7,3 @@
     $ augur --version
    -augur 21.0.0
    +augur 21.0.1
     $ auspice --version
    Failure!
    % echo $?
    1
    ```

    </details>

2. With a tag known to have the same Augur version.

    <details>

    <summary>
    Commands and output
    </summary>

    ```
    % ./devel/validate-platforms -r docker.io -t build-20230220T161818Z
    [linux/amd64] Pulling image...
    docker.io/nextstrain/base:build-20230220T161818Z
    [linux/amd64] Checking that the platform is expected...
    [linux/amd64] Generating report file: /var/folders/rk/s2p6nv1d13lcf0dynjkvxyl80000gp/T/validate-platforms-XXXXXX.OHXS3kXH/linux/amd64
    [linux/amd64] Determining software versions...
    [linux/arm64] Pulling image...
    docker.io/nextstrain/base:build-20230220T161818Z
    [linux/arm64] Checking that the platform is expected...
    [linux/arm64] Generating report file: /var/folders/rk/s2p6nv1d13lcf0dynjkvxyl80000gp/T/validate-platforms-XXXXXX.OHXS3kXH/linux/arm64
    [linux/arm64] Determining software versions...
    The report for linux/amd64 has the following contents:
    $ nextstrain --version
    nextstrain.cli 6.1.0.post1
    $ nextalign --version
    nextalign 2.11.0
    $ nextclade --version
    nextclade 2.11.0
    $ augur --version
    augur 21.0.1
    $ auspice --version
    2.43.0
    $ python3 -c "from importlib.metadata import version; print(version(\"evofr\"))"
    0.1.16
    $ datasets --version
    datasets version: 14.13.0
    $ dataformat version
    14.13.0
    $ python3 -c "from importlib.metadata import version; print(version(\"phylo-treetime\"))"
    0.9.5
    Comparing against other platforms...
    Success!  All versions the same.
    % echo $?
    0
    ```

    </details>

### Post-merge

- [ ] Create issue for checking diff of `pip list` without error-ing

    <!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
