### PR TITLE
compromise proposal: use some of pip list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,24 @@ jobs:
       env:
         DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
+  validate-platforms:
+    name: Validate platforms
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: docker/setup-qemu-action@v2
+
+    - uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: nextstrain-bot
+        password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
+
+    - name: Validate final images
+      run: ./devel/validate-platforms -r ghcr.io -t ${{ needs.build.outputs.tag }}
+
   push-branch:
     if: startsWith(needs.build.outputs.tag, 'branch-') && github.event_name != 'pull_request'
     needs: build
@@ -103,7 +121,7 @@ jobs:
 
   push-build:
     if: startsWith(needs.build.outputs.tag, 'build-')
-    needs: [build, test]
+    needs: [build, test, validate-platforms]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -126,7 +144,7 @@ jobs:
 
   cleanup-registry:
     if: always()
-    needs: [build, test, push-branch, push-build]
+    needs: [build, test, validate-platforms, push-branch, push-build]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,8 @@ RUN pip3 install pysam==0.19.1
 
 # Allow caching to be avoided from here on out by calling
 # docker build --build-arg CACHE_DATE="$(date)"
+# NOTE: All versioned software added below should be checked in
+# devel/validate-platforms.
 ARG CACHE_DATE
 
 # Install our own CLI so builds can do things like `nextstrain deploy`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ variable to a new timestamp first:
 Otherwise, letting the build process use the cached layers will save you time
 during development iterations.
 
+### Validate the images
+
+Before using the images, they should be checked for any inconsistencies.
+
+    ./devel/validate-platforms
+
+The output and exit code will tell you whether validation is successful.
+
 ### Using the images locally
 
 Since the images are pushed directly to the local registry, they are not

--- a/devel/validate-platforms
+++ b/devel/validate-platforms
@@ -40,20 +40,41 @@ main() {
         echo "[$platform] Generating report file: $report"
         mkdir -p "$(dirname "$report")"
 
+        # Versions to track from `pip list`
+        tracked_packages=(bcbio-gff
+            biopython
+            cycler
+            evofr
+            nextstrain-augur
+            nextstrain-cli
+            numpy
+            numpyro
+            pandas
+            phylo-treetime
+            pyfastx
+            pysam
+            rethinkdb
+            scikit-learn
+            scipy
+            snakemake
+            xopen
+        )
+        tracked_packages_string=${tracked_packages[*]}
+        tracked_packages_delim=${tracked_packages_string// /|}
+
         # Create a report file for the platform.
         echo "[$platform] Determining software versions..."
         docker-run "$platform" bash -c '
             PS4="\$ "
             set -x
 
-            nextstrain --version
             nextalign --version
             nextclade --version
-            augur --version
             auspice --version
-            python3 -c "from importlib.metadata import version; print(version(\"evofr\"))"
-            datasets --version
-            dataformat version
+            # datasets --version
+            # dataformat version
+
+            pip list 2>&1 | grep -E "'"$tracked_packages_delim"'"
         ' >"$report" 2>&1
     done
 
@@ -70,7 +91,7 @@ main() {
     else
         echo "Failure!" >&2
         exit 1
-     fi
+    fi
 }
 
 check-platform() {

--- a/devel/validate-platforms
+++ b/devel/validate-platforms
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Validate different platform builds of the final Nextstrain image.
+#
+set -euo pipefail
+
+# Set default values.
+registry=localhost:5000
+tag=latest
+
+# Read command-line arguments.
+while getopts "r:t:" opt; do
+    case "$opt" in
+        r) registry="$OPTARG";;
+        t) tag="$OPTARG";;
+        *) echo "Usage: $0 [-r <registry>] [-t <tag>]" 1>&2; exit 1;;
+    esac
+done
+
+IMAGE="$registry/nextstrain/base:$tag"
+PLATFORMS=(linux/amd64 linux/arm64)
+
+main() {
+    # Check software where downloaded versions are not deterministic at
+    # different points in time (e.g. if "latest" is downloaded).
+
+    local report_dir
+    report_dir="$(mktemp -dt "$(basename "$0")"-XXXXXX)"
+
+    for platform in "${PLATFORMS[@]}"; do
+        echo "[$platform] Pulling image..."
+        docker pull -q --platform "$platform" "$IMAGE"
+
+        echo "[$platform] Checking that the platform is expected..."
+        check-platform "$platform"
+
+        # Initialize a directory for the report file, ensuring slashes in the
+        # platform name are subdirs.
+        report="$report_dir/$platform"
+        echo "[$platform] Generating report file: $report"
+        mkdir -p "$(dirname "$report")"
+
+        # Create a report file for the platform.
+        echo "[$platform] Determining software versions..."
+        docker-run "$platform" bash -c '
+            PS4="\$ "
+            set -x
+
+            nextstrain --version
+            nextalign --version
+            nextclade --version
+            augur --version
+            auspice --version
+            python3 -c "from importlib.metadata import version; print(version(\"evofr\"))"
+            datasets --version
+            dataformat version
+        ' >"$report" 2>&1
+    done
+
+    # Compare contents of the first platform's report file against others.
+    first_report="$report_dir/${PLATFORMS[0]}"
+    echo "The report for ${PLATFORMS[0]} has the following contents:"
+    cat "$first_report"
+
+    echo "Comparing against other platforms..."
+    # NOTE: if running on macOS ≥13, you may need to install GNU diff for the
+    # --from-file option.
+    if cd "$report_dir" && diff --unified=1 --from-file="${PLATFORMS[0]}" "${PLATFORMS[@]:1}"; then
+        echo "Success!  All versions the same." >&2
+    else
+        echo "Failure!" >&2
+        exit 1
+     fi
+}
+
+check-platform() {
+    # Check that the platform is actually what we expect it to be.
+    local platform="$1"
+
+    python_platform_string="$(docker-run "$platform" python -c "import platform; print(platform.platform())")"
+
+    case "$platform" in
+        linux/amd64)
+            if [[ "$python_platform_string" != *"x86_64"* ]]; then
+                echo "Platform $platform not detected." 1>&2; exit 1
+            fi;;
+        linux/arm64)
+            if [[ "$python_platform_string" != *"aarch64"* ]]; then
+                echo "Platform $platform not detected." 1>&2; exit 1
+            fi;;
+        *)
+            echo "Platform $platform not supported." 1>&2; exit 1;;
+    esac
+}
+
+docker-run() {
+    # Run a command under the final Nextstrain image built for a specific
+    # platform.
+    local platform="$1"
+    local command=("${@:2}")
+
+    docker run --platform "$platform" "$IMAGE" "${command[@]}"
+}
+
+main


### PR DESCRIPTION
PR to suggest how to use subset of `pip list`

Not a real PR, but easiest way to propose difference, I think.

The pip list output is nice, better than the "command newline version_number" pattern

```
[linux/amd64] Pulling image...
registry.hub.docker.com/nextstrain/base:latest
[linux/amd64] Checking that the platform is expected...
[linux/amd64] Generating report file: /var/folders/qf/4kkcfypx0gbfb0t9336522_r0000gn/T/validate-platforms-7FIoow/linux/amd64
[linux/amd64] Determining software versions...
[linux/arm64] Pulling image...
registry.hub.docker.com/nextstrain/base:latest
[linux/arm64] Checking that the platform is expected...
[linux/arm64] Generating report file: /var/folders/qf/4kkcfypx0gbfb0t9336522_r0000gn/T/validate-platforms-7FIoow/linux/arm64
[linux/arm64] Determining software versions...
The report for linux/amd64 has the following contents:
$ nextalign --version
nextalign 2.12.0
$ nextclade --version
nextclade 2.12.0
$ auspice --version
2.44.0
$ pip list
$ grep -E 'bcbio-gff|biopython|cycler|evofr|nextstrain-augur|nextstrain-cli|numpy|numpyro|pandas|phylo-treetime|pyfastx|pysam|rethinkdb|scikit-learn|scipy|snakemake|xopen'
bcbio-gff                0.6.9
biopython                1.80
cycler                   0.11.0
evofr                    0.1.16
nextstrain-augur         21.0.1      /nextstrain/augur
nextstrain-cli           6.2.0
numpy                    1.24.2
numpyro                  0.9.2
pandas                   1.5.3
phylo-treetime           0.9.5
pyfastx                  0.8.4
pysam                    0.19.1
rethinkdb                2.4.9
scikit-learn             1.2.1
scipy                    1.10.1
snakemake                5.10.0
xopen                    1.7.0
Comparing against other platforms...
Success!  All versions the same.
```