### PR TITLE
Fix arm64 CVXOPT installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,27 +147,6 @@ RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-
 
 # 3. Install programs via pip
 
-# Build cvxopt on linux/arm64
-# cvxopt, an Augur dependency, does not have pre-built binaries for linux/arm64.
-#
-# First, add system deps for building¹:
-# - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
-# - libsuitesparse-dev: Contains SuiteSparse.
-#
-# Then, "install" (build) separately since the process requires a special
-# environment variable².
-#
-# ¹ https://cvxopt.org/install/#building-and-installing-from-source
-# ² https://github.com/cvxopt/cvxopt/issues/125#issuecomment-407396491
-RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
-      apt-get update && apt-get install -y --no-install-recommends \
-          libopenblas-dev \
-          libsuitesparse-dev \
-   && CVXOPT_SUITESPARSE_INC_DIR=/usr/include/suitesparse \
-      pip3 install cvxopt \
-      ; \
-    fi
-
 # Install jaxlib on linux/arm64
 # jaxlib, an evofr dependency, does not have official pre-built binaries for
 # linux/arm64. A GitHub user has provided them in a fork repo.
@@ -239,6 +218,28 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/fauna master . 
 RUN pip3 install phylo-treetime
 
 # Augur
+
+# Build cvxopt on linux/arm64
+# cvxopt, an Augur dependency, does not have pre-built binaries for linux/arm64.
+#
+# First, add system deps for building¹:
+# - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
+# - libsuitesparse-dev: Contains SuiteSparse.
+#
+# Then, "install" (build) separately since the process requires a special
+# environment variable².
+#
+# ¹ https://cvxopt.org/install/#building-and-installing-from-source
+# ² https://github.com/cvxopt/cvxopt/issues/125#issuecomment-407396491
+RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
+      apt-get update && apt-get install -y --no-install-recommends \
+          libopenblas-dev \
+          libsuitesparse-dev \
+   && CVXOPT_SUITESPARSE_INC_DIR=/usr/include/suitesparse \
+      pip3 install cvxopt \
+      ; \
+    fi
+
 # Augur is an editable install so we can overlay the augur version in the image
 # with --volume=.../augur:/nextstrain/augur and still have it globally
 # accessible and importable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -313,6 +313,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
  && apt-get update && apt-get install -y nodejs
 
+# Used for platform-specific instructions
+ARG TARGETPLATFORM
+
+# Install CVXOPT deps on linux/arm64
+# CVXOPT, an Augur dependency, was built separately above without runtime deps¹
+# packaged like they are for the amd64 wheel.
+#
+# ¹ https://cvxopt.org/install/#building-and-installing-from-source
+RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
+      apt-get update && apt-get install -y --no-install-recommends \
+          libopenblas-base \
+      ; \
+    fi
+
 # Configure bash for interactive usage
 COPY bashrc /etc/bash.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,8 +219,8 @@ RUN pip3 install phylo-treetime
 
 # Augur
 
-# Build cvxopt on linux/arm64
-# cvxopt, an Augur dependency, does not have pre-built binaries for linux/arm64.
+# Build CVXOPT on linux/arm64
+# CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64.
 #
 # First, add system deps for building¹:
 # - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.

--- a/Dockerfile
+++ b/Dockerfile
@@ -224,18 +224,21 @@ RUN pip3 install phylo-treetime
 #
 # First, add system deps for building¹:
 # - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
-# - libsuitesparse-dev: Contains SuiteSparse.
+# - SuiteSparse: Download the source code so it can be built alongside CVXOPT.
 #
 # Then, "install" (build) separately since the process requires a special
 # environment variable².
 #
 # ¹ https://cvxopt.org/install/#building-and-installing-from-source
-# ² https://github.com/cvxopt/cvxopt/issues/125#issuecomment-407396491
+# ² https://cvxopt.org/install/#ubuntu-debian
+WORKDIR /cvxopt
 RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       apt-get update && apt-get install -y --no-install-recommends \
           libopenblas-dev \
-          libsuitesparse-dev \
-   && CVXOPT_SUITESPARSE_INC_DIR=/usr/include/suitesparse \
+   && mkdir SuiteSparse \
+   && curl -fsSL https://api.github.com/repos/DrTimothyAldenDavis/SuiteSparse/tarball/v5.8.1 \
+    | tar xzvpf - --no-same-owner --strip-components=1 -C SuiteSparse \
+   && CVXOPT_SUITESPARSE_SRC_DIR=$(pwd)/SuiteSparse \
       pip3 install cvxopt \
       ; \
     fi


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Previously, cvxopt was unusable on the arm64 variant with this error:

    ImportError: liblapack.so.3: cannot open shared object file: No such file or directory

This makes sense because the CVXOPT installation instructions state that BLAS and LAPACK are required¹ (these are provided by the OpenBLAS package). In c1515608e17fc1f7d933854901ab2c81f51b696e, they were only installed in the builder image since I did not realize they were required during run time.

Interestingly, cvxopt was already usable on the amd64 variant without this change. I'm not sure why.

¹ https://cvxopt.org/install/#building-and-installing-from-source

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Fixes #142 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] `docker run --rm -it nextstrain/base:branch-victorlin-fix-arm64-cvxopt python -c "import cvxopt"` works

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
