### PR TITLE
build: Disable SLSA Provenance metadata for our images

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -68,6 +68,7 @@ docker buildx build \
     --cache-to type=inline \
     --tag "$output_registry/$BUILDER_IMAGE:$tag" \
     --push \
+    --provenance false \
     .
 
 docker buildx build \
@@ -86,4 +87,5 @@ docker buildx build \
     --cache-to type=inline \
     --tag "$output_registry/$FINAL_IMAGE:$tag" \
     --push \
+    --provenance false \
     .


### PR DESCRIPTION
Provenance metadata was newly enabled by default in buildx 0.10.0¹ and entails switching from older, Docker image manifest lists (application/vnd.docker.distribution.manifest.list.v2+json) to the newer, but roughly equivalent-in-concept, OCI image indexes (application/vnd.oci.image.index.v1+json).²

This switch happened automatically for us between these two builds:

    nextstrain/base:build-20230119T003940Z
    nextstrain/base:build-20230321T203820Z

due to an upgrade of buildx from 0.9.1 → 0.10.0 on the GitHub Actions runners we use for CI.

Unfortunately, Singularity doesn't support OCI image indexes (i.e. multi-platform images) until 3.6.0.³  While we'll likely need to require a newer Singularity version at some point anyway⁴, disabling the provenance metadata for now should restore compatibility with Singularity back to its 2.6 series.  We don't need the provenance anyhow.

¹ <https://github.com/docker/buildx/releases/tag/v0.10.0>

² Provenance metadata is attached as additional entries in the image
  index alongside the normal entries for each platform image.

³ <https://github.com/nextstrain/cli/issues/267>
⁴ <https://github.com/nextstrain/cli/issues/274>

Resolves https://github.com/nextstrain/cli/issues/267.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Inspect media type of the image built for this PR
- [x] Test it works with older Singularity
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
