### PR TITLE
Install pango_aliasor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,8 @@ RUN pip3 install git+https://github.com/cov-lineages/constellations.git@v0.1.1
 RUN pip3 install git+https://github.com/cov-lineages/pango-designation.git@19d9a537b9
 RUN pip3 install pysam==0.19.1
 
+# Install pango_aliasor (for forecasts-ncov)
+RUN pip3 install pango_aliasor==0.3.0
 
 # 4. Add unpinned programs
 


### PR DESCRIPTION
Package maintained by myself to simplify aliasing and dealising of pango lineages

Package is pure Python without dependencies and minimal size

Source code: https://github.com/corneliusroemer/pango_aliasor

See further discussion: https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1683137801980639

Blocking for https://github.com/nextstrain/forecasts-ncov/pull/39

TODO:
- [x] Parallel addition to nextstrain/conda-base, see https://github.com/nextstrain/conda-base/pull/25
