### PR TITLE
ci: Test pathogen repo CI builds with the final image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,37 @@ jobs:
       env:
         DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
+  # Run pathogen repo CI builds with the final image
+  test-pathogen-repo-ci:
+    needs: build
+    strategy:
+      # XXX TODO: Test on multiple platforms via the matrix too, as above?
+      matrix:
+        include:
+          - { pathogen: avian-flu,       build-args: auspice/flu_avian_h5n1_ha.json }
+          - { pathogen: ebola }
+          - { pathogen: lassa }
+          - { pathogen: monkeypox }
+          - { pathogen: mumps }
+          - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
+          - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
+          - { pathogen: zika }
+    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    with:
+      repo: nextstrain/${{ matrix.pathogen }}
+      build-args: ${{ matrix.build-args }}
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ghcr.io/nextstrain/base:${{ needs.build.outputs.tag }}
+
+    # XXX FIXME: Jobs which call reusable workflows (uses: …) can't specify
+    # continue-on-error.¹  That's unfortunate, as we don't want to fail the
+    # workflow because of these.  They're more smoke tests than gating tests.
+    #   -trs, 5 May 2023
+    #
+    # ¹ <https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow>
+    #continue-on-error: true
+
   validate-platforms:
     name: Validate platforms
     needs: build


### PR DESCRIPTION
A useful check for if new images will break our pathogen builds.

I included all pathogen repos that already use our pathogen-repo-ci reusable workflow.  It should be minimal effort to maintain this list over time—I expect it to only grow—but perhaps in the future we will want to abstract it out into a shared list of known pathogen repos.

I don't like that we have to copy the build-args for a few of the repos here since it'll be easy for this copy to diverge from the repo's authoritative build-args, but it's necessary for now.  Over time as we work towards increased automation of pathogen builds, I think we can get rid of this build-args copy by further standardizing how each repo configures itself for automation.  For example, instead of specifying build-args in a repo's CI workflow, the args for CI could be stored in a broader workflow metadata file (e.g. nextstrain-workflow.yaml) read by pathogen-repo-ci, or defined by some other convention.

An alternative to directly running pathogen-repo-ci against each repo here would be instead triggering the CI workflows themselves within each repo.  The downside to that is it would divorce the outcomes of those workflows from this one and render them not visible from PRs in this repo.  It would also require updates to each repo to support triggering and passing in of additional parameters (i.e. for the image).  And finally those CI workflows sometimes run other jobs, like linting and other integration tests (e.g. with Cram), that aren't always necessary to run with a new image.

Resolves <https://github.com/nextstrain/docker-base/issues/147>.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
