### PR TITLE
ci: Ignore failures of pathogen-repo-ci builds for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,7 @@ jobs:
       build-args: ${{ matrix.build-args }}
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ghcr.io/nextstrain/base:${{ needs.build.outputs.tag }}
-
-    # XXX FIXME: Jobs which call reusable workflows (uses: …) can't specify
-    # continue-on-error.¹  That's unfortunate, as we don't want to fail the
-    # workflow because of these.  They're more smoke tests than gating tests.
-    #   -trs, 5 May 2023
-    #
-    # ¹ <https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow>
-    #continue-on-error: true
+      continue-on-error: true
 
   validate-platforms:
     name: Validate platforms


### PR DESCRIPTION
This makes them advisory-only, as they're currently broken.¹

We may also opt to leave them advisory-only longer term, as they might
be noisy and not fit for stopping an image release.

Idea for the pass thru this uses from @joverlee521.²

Related-to: <https://github.com/nextstrain/docker-base/pull/148>

¹ <https://github.com/nextstrain/docker-base/pull/148#issuecomment-1539203279>
² <https://github.com/nextstrain/docker-base/pull/148#discussion_r1187794955>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

### Before merge

- [x] Await merge of https://github.com/nextstrain/.github/pull/40
- [x] Drop `tmp!` commit

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
