### PR TITLE
ci: Test pathogen repo CI builds using images on docker.io instead of ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,30 +82,6 @@ jobs:
       env:
         DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
-  # Run pathogen repo CI builds with the final image
-  test-pathogen-repo-ci:
-    needs: build
-    strategy:
-      # XXX TODO: Test on multiple platforms via the matrix too, as above?
-      matrix:
-        include:
-          - { pathogen: avian-flu,       build-args: auspice/flu_avian_h5n1_ha.json }
-          - { pathogen: ebola }
-          - { pathogen: lassa }
-          - { pathogen: monkeypox }
-          - { pathogen: mumps }
-          - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
-          - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
-          - { pathogen: zika }
-    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
-    with:
-      repo: nextstrain/${{ matrix.pathogen }}
-      build-args: ${{ matrix.build-args }}
-      env: |
-        NEXTSTRAIN_DOCKER_IMAGE: ghcr.io/nextstrain/base:${{ needs.build.outputs.tag }}
-      continue-on-error: true
-
   validate-platforms:
     name: Validate platforms
     needs: build
@@ -172,6 +148,37 @@ jobs:
     - name: Copy $TAG + latest images to Docker Hub
       run: |
         ./devel/copy-images -i ghcr.io -o docker.io -t ${{ needs.build.outputs.tag }} -l
+
+  # Run pathogen repo CI builds with the final image
+  test-pathogen-repo-ci:
+    # Only one of push-{branch,build} runs for any given workflow run, and
+    # we're ok with either of them.
+    needs: [build, push-branch, push-build]
+    if: |2
+         success()
+      || needs.push-branch.result == 'success'
+      || needs.push-build.result == 'success'
+    strategy:
+      # XXX TODO: Test on multiple platforms via the matrix too, as above?
+      matrix:
+        include:
+          - { pathogen: avian-flu,       build-args: auspice/flu_avian_h5n1_ha.json }
+          - { pathogen: ebola }
+          - { pathogen: lassa }
+          - { pathogen: monkeypox }
+          - { pathogen: mumps }
+          - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
+          - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
+          - { pathogen: zika }
+    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    with:
+      repo: nextstrain/${{ matrix.pathogen }}
+      build-args: ${{ matrix.build-args }}
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base:${{ needs.build.outputs.tag }}
+      continue-on-error: true
+    secrets: inherit
 
   # Delete the builder and final images from GitHub Container Registry.
   cleanup-registry:


### PR DESCRIPTION
This should fix the currently-broken test-pathogen-repo-ci jobs when our CI runs on master² (and they should continue to work on branches too). It requires a little rearranging of jobs in the workflow, with a little additional and unfortunate complexity due to conditionals.

This works around a Nextstrain CLI bug with registries other than docker.io¹ during `nextstrain update docker` (and `nextstrain setup docker`), which is run as part of our setup-nextstrain-cli action used by this workflow.  Ideally we'll fix that bug and then be able to revert this, especially since we might actually want to condition the pushing to docker.io on the outcome of these test jobs in the future.

¹ <https://github.com/nextstrain/cli/issues/279>
² <https://github.com/nextstrain/docker-base/pull/148#issuecomment-1539203279>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
