### PR TITLE
ci: Only run test-pathogen-repo-ci builds using the Docker runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,11 @@ jobs:
     with:
       repo: nextstrain/${{ matrix.pathogen }}
       build-args: ${{ matrix.build-args }}
+      runtimes: |
+        - docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base:${{ needs.build.outputs.tag }}
+      artifact-name: ${{ matrix.pathogen }}-outputs
       continue-on-error: true
     secrets: inherit
 


### PR DESCRIPTION
The point is to test the new Docker runtime image, so we don't need to spend the time testing the Conda runtime too.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

https://github.com/nextstrain/.github/pull/42

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

### Before merge

- [x] Await merge of https://github.com/nextstrain/.github/pull/42
- [ ] Drop `tmp!` commit

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
