### PR TITLE
Revert "build: Use different cache and output registries"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build multi-platform builder and final images with caching from Docker Hub;
-  # push to GitHub Container Registry.
+  # Build multi-platform builder and final images with caching from Docker Hub
+  # and GitHub Container Registry; push to GitHub Container Registry.
   build:
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +42,7 @@ jobs:
         username: nextstrain-bot
         password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
 
-    - run: ./devel/build -p linux/amd64,linux/arm64 -c docker.io -o ghcr.io -t $TAG
+    - run: ./devel/build -p linux/amd64,linux/arm64 -r ghcr.io -t $TAG
 
     outputs:
       tag: ${{ env.TAG }}

--- a/devel/build
+++ b/devel/build
@@ -3,10 +3,9 @@
 # Builds the nextstrain/base and nextstrain/base-builder images with useful
 # caching and pushes to a registry.
 #
-# By default this tags images using "latest" and pushes to localhost:5000 with
-# same-registry caching, but you can provide a custom tag with -t <tag> and
-# specify different registries with -o <output_registry> and
-# -c <cache_registry>.
+# By default this tags images using "latest" and pushes to localhost:5000, but
+# you can provide a custom tag with -t <tag> and specify a different
+# registry with -r <registry>.
 #
 # Set CACHE_DATE in your environment to force layers after our custom cache
 # point to be re-built. See the ARG CACHE_DATE line in the Dockerfile for more
@@ -16,18 +15,16 @@ set -euo pipefail
 
 # Set default values.
 platform=linux/amd64
-cache_registry=localhost:5000
-output_registry=localhost:5000
+registry=localhost:5000
 tag=latest
 
 # Read command-line arguments.
-while getopts "p:c:o:t:" opt; do
+while getopts "p:r:t:" opt; do
     case "$opt" in
         p) platform="$OPTARG";;
-        c) cache_registry="$OPTARG";;
-        o) output_registry="$OPTARG";;
+        r) registry="$OPTARG";;
         t) tag="$OPTARG";;
-        *) echo "Usage: $0 [-p <platform>] [-c <cache_registry>] [-o <output_registry>] [-t <tag>]" 1>&2; exit 1;;
+        *) echo "Usage: $0 [-p <platform>] [-r <registry>] [-t <tag>]" 1>&2; exit 1;;
     esac
 done
 
@@ -63,10 +60,10 @@ docker buildx build \
     --build-arg CACHE_DATE \
     --cache-from "$BUILDER_IMAGE:latest" \
     --cache-from "$BUILDER_IMAGE:$tag" \
-    --cache-from "$cache_registry/$BUILDER_IMAGE:latest" \
-    --cache-from "$cache_registry/$BUILDER_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
     --cache-to type=inline \
-    --tag "$output_registry/$BUILDER_IMAGE:$tag" \
+    --tag "$registry/$BUILDER_IMAGE:$tag" \
     --push \
     --provenance false \
     .
@@ -80,12 +77,12 @@ docker buildx build \
     --cache-from "$BUILDER_IMAGE:$tag" \
     --cache-from "$FINAL_IMAGE:latest" \
     --cache-from "$FINAL_IMAGE:$tag" \
-    --cache-from "$cache_registry/$BUILDER_IMAGE:latest" \
-    --cache-from "$cache_registry/$BUILDER_IMAGE:$tag" \
-    --cache-from "$cache_registry/$FINAL_IMAGE:latest" \
-    --cache-from "$cache_registry/$FINAL_IMAGE:$tag" \
+    --cache-from "$registry/$BUILDER_IMAGE:latest" \
+    --cache-from "$registry/$BUILDER_IMAGE:$tag" \
+    --cache-from "$registry/$FINAL_IMAGE:latest" \
+    --cache-from "$registry/$FINAL_IMAGE:$tag" \
     --cache-to type=inline \
-    --tag "$output_registry/$FINAL_IMAGE:$tag" \
+    --tag "$registry/$FINAL_IMAGE:$tag" \
     --push \
     --provenance false \
     .

--- a/devel/build
+++ b/devel/build
@@ -73,6 +73,7 @@ docker buildx build \
     --builder "$builder" \
     --platform "$platform" \
     --build-arg GIT_REVISION \
+    --build-arg CACHE_DATE \
     --cache-from "$BUILDER_IMAGE:latest" \
     --cache-from "$BUILDER_IMAGE:$tag" \
     --cache-from "$FINAL_IMAGE:latest" \


### PR DESCRIPTION
This reverts commit 917a04806cffdb76dda815b79479f05b1879e31a and fixes the comment added by efbbfb99c8118ccf0d201aa863c88c8a7bbb4d8d.

We need to cache from ghcr.io because otherwise the build of nextstrain/base doesn't find the layers from the just-built nextstrain/base-builder pushed to ghcr.io.  Instead, it seemingly uses layers from an older nextstrain/base-builder on docker.io.

My understanding is that we were always pulling caches from docker.io (_and_ ghcr.io) because docker.io is the default registry when none is specified, and we use --cache-from lines without a registry specified.

See <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1683932186614689>.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
