### PR TITLE
wip: fast build only amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Platforms to build for'
+        required: true
+        default: "linux/amd64"
 
 # Prevent intermediate images from being used by another run.
 # Concurrency group is unique:
@@ -32,7 +40,8 @@ jobs:
       # and hyphens.
       run: echo "TAG=branch-${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}" | tee -a $GITHUB_ENV
 
-    - uses: docker/setup-qemu-action@v2
+    - if: ${{ inputs.platforms }} == 'linux/amd64,linux/arm64'
+      uses: docker/setup-qemu-action@v2
 
     # GITHUB_TOKEN is unreliable¹ so use a token from nextstrain-bot.
     # ¹ https://github.com/docker/build-push-action/issues/463#issuecomment-939394233
@@ -42,7 +51,7 @@ jobs:
         username: nextstrain-bot
         password: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_MANAGE_PACKAGES }}
 
-    - run: ./devel/build -p linux/amd64,linux/arm64 -c docker.io -o ghcr.io -t $TAG
+    - run: ./devel/build -p ${{ inputs.platforms }} -c docker.io -o ghcr.io -t $TAG
 
     outputs:
       tag: ${{ env.TAG }}


### PR DESCRIPTION
### Description of proposed changes

QEMU arm builds slow builds down _a lot_. With AMD only, CI would take around 10 min, with ARM as well, it's 60min.

For faster feedback loops it could make sense to be able to run CI with AMD only.

The way I've set it up is definitely not good, but it's a POC. Could be helpful for @joverlee521 while working on #155 for example.