### PR TITLE
Omit dev deps when installing Auspice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,7 @@ RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/
 # ⁴ https://github.com/mapbox/node-pre-gyp/blob/v1.0.10/lib/node-pre-gyp.js#L186
 WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
- && npm update && npm install && npm link
+ && npm install && npm link
 
 # Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
 RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/datasets

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,7 @@ RUN curl -fsSL -o /final/bin/nextclade2 https://github.com/nextstrain/nextclade/
 # ⁴ https://github.com/mapbox/node-pre-gyp/blob/v1.0.10/lib/node-pre-gyp.js#L186
 WORKDIR /nextstrain/auspice
 RUN /builder-scripts/download-repo https://github.com/nextstrain/auspice release . \
- && npm install && npm link
+ && npm install --omit dev && npm link
 
 # Add NCBI Datasets command line tools for access to NCBI Datsets Virus Data Packages
 RUN curl -fsSL -o /final/bin/datasets https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-${TARGETARCH}/datasets


### PR DESCRIPTION
This avoids disk-heavy deps like Puppeteer, which bundle a whole Chromium install.  Based on some rough comparisons, I expected this to shave about 600MB from the uncompressed image size and a local test build bore that out.

The node_modules/ tree is infamously large and bloated.  The usual culprits are non-source files that are commonly included in package distributions but not needed at run time.  So there is surely more we could shave off here, but this is a huge easy start.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
