### PR TITLE
start-localhost-registry: Start container if it already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := bash -euo pipefail
 .PHONY: local-image test
 
 local-image:
-	./devel/start-localhost-registry || true
+	./devel/start-localhost-registry
 	./devel/build
 	
 	# Don't pull base-builder image since it's huge and not needed for local

--- a/devel/start-localhost-registry
+++ b/devel/start-localhost-registry
@@ -18,12 +18,16 @@ NAME=nextstrain-local-registry
 # Docker image that provides the registry service.
 IMAGE=registry:2
 
-docker run \
-    --detach \
-    --publish 127.0.0.1:"$PORT":"$PORT" \
-    --restart always \
-    --name "$NAME" \
-    --volume "$DATA":/var/lib/registry \
-    --user "$(id -u):$(id -g)" \
-    "$IMAGE" \
-    > /dev/null
+if docker container inspect "$NAME" &>/dev/null; then
+    docker container start "$NAME"
+else
+    docker run \
+        --detach \
+        --publish 127.0.0.1:"$PORT":"$PORT" \
+        --restart always \
+        --name "$NAME" \
+        --volume "$DATA":/var/lib/registry \
+        --user "$(id -u):$(id -g)" \
+        "$IMAGE" \
+        > /dev/null
+fi


### PR DESCRIPTION
Previously an error occurred if the container existed because container creation tried to use a name already in use.  It's safe to "start" a container that's already started, so this makes the program idempotent.

This also handles the case of the container existing but being stopped, which previously wasn't handled.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Works locally when the container exists and when it doesn't
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
