### PR TITLE
Build CVXOPT in cached section

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -290,31 +290,6 @@ RUN pip3 install pysam==0.19.1
 # Install pango_aliasor (for forecasts-ncov)
 RUN pip3 install pango_aliasor==0.3.0
 
-
-# 2. Add unpinned programs
-
-# Allow caching to be avoided from here on out in this stage by calling
-# docker build --build-arg CACHE_DATE="$(date)"
-# NOTE: All versioned software added below should be checked in
-# devel/validate-platforms.
-ARG CACHE_DATE
-
-# Add helper scripts
-COPY builder-scripts/ /builder-scripts/
-
-# Install our own CLI so builds can do things like `nextstrain deploy`
-RUN pip3 install nextstrain-cli
-
-# Fauna
-WORKDIR /nextstrain/fauna
-RUN /builder-scripts/download-repo https://github.com/nextstrain/fauna master . \
- && pip3 install --requirement=requirements.txt
-
-# Add Treetime
-RUN pip3 install phylo-treetime
-
-# Augur
-
 # Build CVXOPT on linux/arm64
 # CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64.
 #
@@ -339,10 +314,34 @@ RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
    && curl -fsSL https://api.github.com/repos/DrTimothyAldenDavis/SuiteSparse/tarball/v5.8.1 \
     | tar xzvpf - --no-same-owner --strip-components=1 -C SuiteSparse \
    && CVXOPT_SUITESPARSE_SRC_DIR=$(pwd)/SuiteSparse \
-      pip3 install cvxopt \
+      pip3 install cvxopt==1.3.1 \
       ; \
     fi
 
+
+# 2. Add unpinned programs
+
+# Allow caching to be avoided from here on out in this stage by calling
+# docker build --build-arg CACHE_DATE="$(date)"
+# NOTE: All versioned software added below should be checked in
+# devel/validate-platforms.
+ARG CACHE_DATE
+
+# Add helper scripts
+COPY builder-scripts/ /builder-scripts/
+
+# Install our own CLI so builds can do things like `nextstrain deploy`
+RUN pip3 install nextstrain-cli
+
+# Fauna
+WORKDIR /nextstrain/fauna
+RUN /builder-scripts/download-repo https://github.com/nextstrain/fauna master . \
+ && pip3 install --requirement=requirements.txt
+
+# Add Treetime
+RUN pip3 install phylo-treetime
+
+# Augur
 # Augur is an editable install so we can overlay the augur version in the image
 # with --volume=.../augur:/nextstrain/augur and still have it globally
 # accessible and importable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -291,19 +291,23 @@ RUN pip3 install pysam==0.19.1
 RUN pip3 install pango_aliasor==0.3.0
 
 # Build CVXOPT on linux/arm64
-# CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64.
+# CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64¹.
 #
-# First, add system deps for building¹:
+# First, add system deps for building²:
 # - gcc: C compiler.
 # - libc6-dev: C libraries and header files.
 # - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
 # - SuiteSparse: Download the source code so it can be built alongside CVXOPT.
 #
 # Then, "install" (build) separately since the process requires a special
-# environment variable².
+# environment variable³.
 #
-# ¹ https://cvxopt.org/install/#building-and-installing-from-source
-# ² https://cvxopt.org/install/#ubuntu-debian
+# ¹ https://github.com/cvxopt/cvxopt-wheels/issues/12
+# ² https://cvxopt.org/install/#building-and-installing-from-source
+# ³ https://cvxopt.org/install/#ubuntu-debian
+#
+# TODO: If this is removed, the installation of libopenblas in the final stage
+# should also be removed.
 WORKDIR /cvxopt
 RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This build is the only build that runs under emulation in the current multi-platform CI build. The step alone takes upwards of 15 minutes.

Since this is an external tool, pinning to the current latest version seems reasonable. The trade-off is manual version bumps for improved CI build times.

I also hope that CVXOPT will eventually provide wheels for linux/arm64. If/when that happens, the separate installation can be removed entirely.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A, I thought of this after seeing build summaries produced by #168. Using that PR as the base of this one to have build summaries here.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Re-running the CI workflow shows that CVXOPT is cached, improving build time ([ref](https://github.com/nextstrain/docker-base/actions/workflows/ci.yml?query=branch%3Avictorlin%2Fcache-cvxopt-build+event%3Apush))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
