### PR TITLE
Update jaxlib for evofr on linux/arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # linux/arm64. A GitHub user has provided them in a fork repo.
 # https://github.com/google/jax/issues/7097#issuecomment-1110730040
 RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
-      pip3 install https://github.com/yoziru/jax/releases/download/jaxlib-v0.3.25/jaxlib-0.3.25-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl \
+      pip3 install https://github.com/yoziru/jax/releases/download/jaxlib-v0.4.6/jaxlib-0.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl \
       ; \
     fi
 
@@ -354,6 +354,9 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/augur "$(/build
  && pip3 install --editable .
 
 # Add evofr for forecasting
+# NOTE: if there is an issue with the evofr installation on linux/arm64, make
+# sure to check that the jaxlib installation above satisfies the latest evofr
+# dependency requirements.
 RUN pip3 install evofr
 
 # ———————————————————————————————————————————————————————————————————— #


### PR DESCRIPTION
### Description of proposed changes

The latest release of evofr included updates to its dependencies that updated the minimum version for jaxlib.¹ I'm using the latest release of jaxlib available in the user forked repo since there's still no official pre-built binaries for linux/arm64.²

I did not realize this change was needed until I saw the "Validate Platform" job fail in the CI run³ that I triggered to update evofr to v0.1.20.

¹ https://github.com/blab/evofr/commit/46f744b605c258d6f3d3b7b3ac8bc877f8e4ba22 
² https://github.com/google/jax/issues/7097
³ https://github.com/nextstrain/docker-base/actions/runs/5480222698


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
