### PR TITLE
Add git to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -371,6 +371,7 @@ SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 # ca-certificates: [Dockerfile] for secure HTTPS connections; may be used by workflows
 # curl: [Dockerfile] for downloading binaries directly; may be used by workflows
 # dos2unix: tsv-utils needs unix line endings
+# git: used to clone workflows within a Docker instance (e.g., through GitPod)
 # jq: may be used by workflows
 # less: for usability in an interactive prompt
 # libgomp1: for running FastTree
@@ -385,6 +386,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         dos2unix \
+        git \
         gzip \
         jq \
         less \


### PR DESCRIPTION
### Description of proposed changes

Adds git back to runtime dependencies to enable cloning of workflow repositories from within a Docker instance. In the short term, this functionality allows use to use GitPod with the base Docker image.

### Testing

- [x] Checks pass
- [x] Confirm that GitPod loads with this branch's Docker image now that git is available

