### PR TITLE
Jax and jaxlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -253,12 +253,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # 1. Install programs via pip
 
-# Install jaxlib on linux/arm64
+# Install jaxlib & jax on linux/arm64
 # jaxlib, an evofr dependency, does not have official pre-built binaries for
 # linux/arm64. A GitHub user has provided them in a fork repo.
 # https://github.com/google/jax/issues/7097#issuecomment-1110730040
+# Also hard-coding jax version here since it needs to match the jaxlib version
+# The minimum version requirement for jaxlib is checked at runtime rather than by pip
+# https://jax.readthedocs.io/en/latest/jep/9419-jax-versioning.html#how-are-jax-and-jaxlib-versioned
 RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       pip3 install https://github.com/yoziru/jax/releases/download/jaxlib-v0.4.6/jaxlib-0.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl \
+          jax==0.4.6 \
       ; \
     fi
 


### PR DESCRIPTION
### Description of proposed changes
Pin jax version for evofr on linux/arm64 since jax has a minimum version requirement for jaxlib that is _not_ checked by package version constraints in pip.¹ Instead, the jaxlib version is checked at runtime. This led to a mismatch of versions when only pinning jaxlib.²

Also updating both the latest available version of jaxlib in the user forked repo since I'm already updating the Dockerfile. 

¹ https://jax.readthedocs.io/en/latest/jep/9419-jax-versioning.html#how-are-jax-and-jaxlib-versioned
² https://github.com/nextstrain/forecasts-ncov/pull/50#issuecomment-1629841748

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Follow-up to https://github.com/nextstrain/docker-base/pull/171

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
