### PR TITLE
Bump snakemake pin to 7.32.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -273,8 +273,8 @@ RUN pip3 install envdir==1.0.1
 RUN pip3 install awscli==1.18.195
 
 # Install Snakemake and related optional dependencies.
-# Pinned to 7.24.1 for stability (2023-03-13)
-RUN pip3 install snakemake==7.24.1
+# Pinned to 7.32.3 for stability (2023-09-09)
+RUN pip3 install snakemake==7.32.3
 # Google Cloud Storage package is required for Snakemake to fetch remote files
 # from Google Storage URIs.
 RUN pip3 install google-cloud-storage==2.7.0


### PR DESCRIPTION
Since our our last snakemake pin bump ~6 months ago
snakemake has added support for a default profile
that allows reducing required command line flags to
a mininmum. Without default profile, one always either
needs to explicitly specify a profile or set things like
`--cores all` which is very annoying.

Now, you can simply put those flags in `profiles/default/config.yaml`
and they'll automatically be used when you invoke `snakemake`

7.32.3 appears to be reasonably stable, no major bugs reported in a month
I've used it in production for a month now, without issues.

Checklist:

- [ ] Once this is agreed upon, we should mirror the bump to conda-base