### PR TITLE
Add nano and vim-tiny for usability in interactive prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -317,10 +317,12 @@ SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 # less: for usability in an interactive prompt
 # libgomp1: for running FastTree
 # libsqlite3: for pyfastx (for Augur)
+# nano: for usability in an interactive prompt
 # ncbi-blast+: for GenoFLU in avian-flu
 # perl: for running VCFtools
 # ruby: may be used by workflows
 # sqlite3: for `augur merge`
+# vim-tiny: for usability in an interactive prompt
 # wget: may be used by workflows
 # zlib1g: for pyfastx (for Augur)
 # nodejs: for running Auspice
@@ -335,11 +337,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         less \
         libgomp1 \
         libsqlite3-0 \
+	      nano \
         ncbi-blast+ \
         perl \
         ruby \
         sqlite3 \
         util-linux \
+        vim-tiny \
         wget \
         xz-utils \
         zip unzip \


### PR DESCRIPTION
Resolves #177

Image size increase should be <1MB unless some libraries are added as well (we'll see in CI):

```bash
$ du -h | grep vim
12K     ./etc/vim
4.0K    ./var/lib/vim/addons
8.0K    ./var/lib/vim
12K     ./usr/share/bug/vim-tiny
32K     ./usr/share/doc/vim-common
32K     ./usr/share/doc/vim-tiny
16K     ./usr/share/vim/vim82/doc
24K     ./usr/share/vim/vim82
28K     ./usr/share/vim

$ du -h | grep nano
4.0K    ./usr/share/doc/nano/examples
12K     ./usr/share/doc/nano
36K     ./usr/share/nano/extra
196K    ./usr/share/nano
4.0K    ./nextstrain/.local/share/nano
```

