### PR TITLE
Configure Nextstrain CLI to use the ambient runtime inside this runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -493,6 +493,13 @@ RUN useradd nextstrain \
     --home-dir /nextstrain \
     --no-log-init
 
+# No nesting of runtimes, please.  Use the ambient runtime inside this runtime.
+ENV NEXTSTRAIN_HOME=/nextstrain
+RUN nextstrain check-setup --set-default ambient \
+ && chown nextstrain:nextstrain /nextstrain/config \
+ && chmod a+rw /nextstrain/config \
+ && rm -f /nextstrain/lock
+
 # The host should bind mount the pathogen build dir into /nextstrain/build.
 WORKDIR /nextstrain/build
 RUN chown nextstrain:nextstrain /nextstrain/build


### PR DESCRIPTION
If users enter a `nextstrain shell` with this Docker runtime, we want `nextstrain` inside that to use the ambient environment.

Reported by @corneliusroemer in Slack.¹

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1694718932379359>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually test inside images
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
