### PR TITLE
Install jaxlib from PyPI on linux/arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -253,19 +253,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # 1. Install programs via pip
 
-# Install jaxlib & jax on linux/arm64
-# jaxlib, an evofr dependency, does not have official pre-built binaries for
-# linux/arm64. A GitHub user has provided them in a fork repo.
-# https://github.com/google/jax/issues/7097#issuecomment-1110730040
-# Also hard-coding jax version here since it needs to match the jaxlib version
-# The minimum version requirement for jaxlib is checked at runtime rather than by pip
-# https://jax.readthedocs.io/en/latest/jep/9419-jax-versioning.html#how-are-jax-and-jaxlib-versioned
-RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
-      pip3 install https://github.com/yoziru/jax/releases/download/jaxlib-v0.4.6/jaxlib-0.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl \
-          jax==0.4.6 \
-      ; \
-    fi
-
 # Install envdir, which is used by pathogen builds
 RUN pip3 install envdir==1.0.1
 
@@ -358,9 +345,6 @@ RUN /builder-scripts/download-repo https://github.com/nextstrain/augur "$(/build
  && pip3 install --editable .
 
 # Add evofr for forecasting
-# NOTE: if there is an issue with the evofr installation on linux/arm64, make
-# sure to check that the jaxlib installation above satisfies the latest evofr
-# dependency requirements.
 RUN pip3 install evofr
 
 # ———————————————————————————————————————————————————————————————————— #


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

The PyPI release of jaxlib version 0.4.18 includes Linux aarch64 wheels¹. The current dependency definition in evofr² should allow this latest version to be pulled automatically.

¹ https://pypi.org/project/jaxlib/0.4.18/#files
² https://github.com/blab/evofr/blob/fa042389da267a7723f33dfaece9dd12f29dcaae/pyproject.toml#L13

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Closes #119.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
