### PR TITLE
Include Make in builder-target-platform image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,10 +245,12 @@ ARG TARGETARCH
 # git: for git pip installs
 # gcc: for building datrie (for Snakemake)
 # libsqlite3-dev, zlib1g-dev: for building pyfastx (for Augur)
+# make: for building isal (if necessary, for Augur)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         gcc \
         git \
+        make \
         jq \
         libsqlite3-dev \
         zlib1g-dev


### PR DESCRIPTION
Required for building the Python isal package (for Augur) when there aren't wheels available (such as with recent version 1.5.2).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
