### PR TITLE
Remove pyfastx build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -244,7 +244,6 @@ ARG TARGETARCH
 # curl, jq: used in builder-scripts/latest-augur-release-tag
 # git: for git pip installs
 # gcc, libc6-dev: for building datrie (for Snakemake)
-# libsqlite3-dev, zlib1g-dev: for building pyfastx (for Augur)
 # make: for building isal (if necessary, for Augur)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
@@ -252,9 +251,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         libc6-dev \
         make \
-        jq \
-        libsqlite3-dev \
-        zlib1g-dev
+        jq
 
 
 # 1. Install programs via pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,13 +243,14 @@ ARG TARGETARCH
 # Add system deps for building
 # curl, jq: used in builder-scripts/latest-augur-release-tag
 # git: for git pip installs
-# gcc: for building datrie (for Snakemake)
+# gcc, libc6-dev: for building datrie (for Snakemake)
 # libsqlite3-dev, zlib1g-dev: for building pyfastx (for Augur)
 # make: for building isal (if necessary, for Augur)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         gcc \
         git \
+        libc6-dev \
         make \
         jq \
         libsqlite3-dev \


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Augur version 23.1.1 supports versions of pyfastx that provide wheels for Python 3.10.
    
Note that runtime dependencies are still necessary.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Follow-up to https://github.com/nextstrain/augur/pull/1335
- Reverts 485b3e5bff48c0bb8f5909dce4cb08990917709a

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Release new version of Augur ([done](https://github.com/nextstrain/augur/actions/runs/6790583852))
- [x] `pyfastx` works in `nextstrain shell` 

    ```sh
    nextstrain shell --docker --image=docker.io/nextstrain/base:branch-victorlin-use-prebuilt-pyfastx .
    # make a copy to avoid permission-related errors
    cp /nextstrain/augur/tests/data/aa-seq_h3n2_ha_2y_HA1.fasta .
    python -c "import pyfastx; fa = pyfastx.Fasta('aa-seq_h3n2_ha_2y_HA1.fasta'); print(list(fa.keys()))"
    ```
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
