### PR TITLE
Symlink default nextclade to nextclade3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,10 +141,8 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/2.14.0/
   && ln -sv nextalign2 /final/bin/nextalign
 
 # Download Nextclade v2
-# Set default Nextclade version to 2
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextclade-$(/builder-scripts/target-triple) \
-  -o /final/bin/nextclade2 \
-  && ln -sv nextclade2 /final/bin/nextclade
+  -o /final/bin/nextclade2
 
 # Download tsv-utils
 # NOTE: Running this program requires support for emulation on the Docker host
@@ -188,9 +186,9 @@ ARG CACHE_DATE
 # Nextalign. Since v3 there is only Nextclade, which can do both.
 # TODO: After Nextclade 3 is released, update the URL to download the latest
 # version instead of hardcoded.
-# TODO: At some point, update the v2 binary symlinks to use Nextclade v3.
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/3.0.0-alpha.2/nextclade-$(/builder-scripts/target-triple) \
-  -o /final/bin/nextclade3
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/3.0.0/nextclade-$(/builder-scripts/target-triple) \
+  -o /final/bin/nextclade3  \
+  && ln -sv nextclade3 /final/bin/nextclade
 
 # Auspice
 # Building auspice means we can run it without hot-reloading, which is


### PR DESCRIPTION
This might break programs that use old nextclade2 syntax

I've gone through nextstrain workflows to make sure we explicitly use nextclade2/3 so few failures are expected to happen

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
