### PR TITLE
Use Nextclade v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,12 +184,8 @@ RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-
 ARG CACHE_DATE
 
 # Download Nextclade v3
-# Note: Before v3 there used to be separate binaries for Nextclade and
-# Nextalign. Since v3 there is only Nextclade, which can do both.
-# TODO: After Nextclade 3 is released, update the URL to download the latest
-# version instead of hardcoded.
 # TODO: At some point, update the v2 binary symlinks to use Nextclade v3.
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/3.0.0-alpha.2/nextclade-$(/builder-scripts/target-triple) \
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-$(/builder-scripts/target-triple) \
   -o /final/bin/nextclade3
 
 # Auspice

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,10 +141,8 @@ RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/2.14.0/
   && ln -sv nextalign2 /final/bin/nextalign
 
 # Download Nextclade v2
-# Set default Nextclade version to 2
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/download/2.14.0/nextclade-$(/builder-scripts/target-triple) \
-  -o /final/bin/nextclade2 \
-  && ln -sv nextclade2 /final/bin/nextclade
+  -o /final/bin/nextclade2
 
 # Download tsv-utils
 # NOTE: Running this program requires support for emulation on the Docker host
@@ -184,9 +182,10 @@ RUN curl -fsSL https://github.com/lh3/minimap2/releases/download/v2.24/minimap2-
 ARG CACHE_DATE
 
 # Download Nextclade v3
-# TODO: At some point, update the v2 binary symlinks to use Nextclade v3.
+# Set default Nextclade version to 3
 RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-$(/builder-scripts/target-triple) \
-  -o /final/bin/nextclade3
+  -o /final/bin/nextclade3 \
+  && ln -sv nextclade3 /final/bin/nextclade
 
 # Auspice
 # Building auspice means we can run it without hot-reloading, which is


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Unpin Nextclade v3 alpha and use the latest version of Nextclade as default.

Any unmigrated workflows should use `nextclade2` instead of `nextclade`. See the Nextclade v2 → v3 [migration docs](https://docs.nextstrain.org/projects/nextclade/page/user/migration-v3.html) for details.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
