### PR TITLE
Unpin Biopython

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -337,10 +337,9 @@ RUN pip3 install phylo-treetime
 # Augur is an editable install so we can overlay the augur version in the image
 # with --volume=.../augur:/nextstrain/augur and still have it globally
 # accessible and importable.
-# Pin Biopython 1.81: https://github.com/nextstrain/augur/issues/1373
 WORKDIR /nextstrain/augur
 RUN /builder-scripts/download-repo https://github.com/nextstrain/augur "$(/builder-scripts/latest-augur-release-tag)" . \
- && pip3 install --editable . biopython==1.81
+ && pip3 install --editable .
 
 # Add evofr for forecasting
 RUN pip3 install evofr


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This reverts commit "Pin Biopython 1.81" (4edf28247), which is no longer necessary as of Augur version 24.1.0.

<https://github.com/nextstrain/augur/releases/tag/24.1.0>

## Related issue(s)

- Reverts #200

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
