### PR TITLE
ci: Remove python-version input to setup-nextstrain-cli action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,6 @@ jobs:
         DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Run zika-tutorial
       run: |


### PR DESCRIPTION
Deprecated and no longer used as setup-python isn't called.

Related-to: <https://github.com/nextstrain/.github/pull/55>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
