### PR TITLE
Dockerfile: Upgrade csvtk to v0.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/downl
  && rm -f tsv-utils.tar.gz
 
 # Download csvtk
-RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.24.0/csvtk_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
+RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.30.0/csvtk_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download seqkit
 RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin


### PR DESCRIPTION
Prompted by internal conversation on Slack¹ that linked to issue indicating csvtk does not treat quotes in TSVs correctly.²

The suggested workaround is to wrap csvtk commands with the new `csvtk fix-quotes` and `csvtk del-quotes` commands. These were added in v0.29.0, so we need to upgrade csvtk here in order to use the workaround. I figured we might as well upgrade to use the latest available version.

Nextstrain conda-base has been using csvtk v0.30.0 since 20240318T235157Z without any issues and I did not see any breaking changes in the csvtk release page.

¹ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1713392993380609 
² https://github.com/shenwei356/csvtk/issues/130


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (avian-flu pathogen-repo-ci failure is unrelated)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
