### PR TITLE
Use AWS CLI v2

### DIFF
--- a/tests/envdir-url.t
+++ b/tests/envdir-url.t
@@ -24,7 +24,7 @@ Files are populated from NEXTSTRAIN_ENVD_URL.
 
   $ aws s3 cp --quiet env.d.zip "$NEXTSTRAIN_ENVD_URL"
 
-  $ docker run --rm -e NEXTSTRAIN_ENVD_URL --env=AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,SESSION_TOKEN} "$IMAGE" \
+  $ docker run --rm -e NEXTSTRAIN_ENVD_URL --env=AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,SESSION_TOKEN,DEFAULT_REGION} "$IMAGE" \
   >   bash -eu -c 'echo "$a"; echo "$b"'
   download: s3://nextstrain-tmp/*.zip to ../env.d.zip (glob)
   Archive:  /nextstrain/env.d.zip
@@ -37,7 +37,7 @@ Files are populated from NEXTSTRAIN_ENVD_URL.
 
 Files and NEXTSTRAIN_ENVD_URL are removed with NEXTSTRAIN_DELETE_ENVD=1.
 
-  $ docker run --rm -e NEXTSTRAIN_DELETE_ENVD=1 -e NEXTSTRAIN_ENVD_URL --env=AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,SESSION_TOKEN} "$IMAGE" \
+  $ docker run --rm -e NEXTSTRAIN_DELETE_ENVD=1 -e NEXTSTRAIN_ENVD_URL --env=AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,SESSION_TOKEN,DEFAULT_REGION} "$IMAGE" \
   >   bash -eu -c 'echo "$a"; echo "$b"; ls -1 /nextstrain/env.d'
   download: s3://nextstrain-tmp/*.zip to ../env.d.zip (glob)
   Archive:  /nextstrain/env.d.zip


### PR DESCRIPTION
## Description of proposed changes

Update AWS CLI to v2

We were running into dependency issues with awscli v1, which was
installed via Pip.¹

Update to AWS CLI v2 which is _not_ installed via Pip.
Instead of working around the absolute path symlinks created by running
`./aws/install`, we are "just installing the files ourselves"² and
creating the symlink for `/final/bin/aws`.

¹ <https://github.com/nextstrain/docker-base/issues/213>
² <https://github.com/nextstrain/docker-base/pull/214#discussion_r1628880435>

## Related issue(s)

Resolves #213 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
