### PR TITLE
Isolate AWS CLI (v1) into its own Python venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -253,7 +253,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip3 install envdir==1.0.1
 
 # Install tooling for our AWS Batch builds, which use `aws s3`.
-RUN pip3 install awscli==1.18.195
+RUN python3 -m venv /usr/local/libexec/awscli \
+ && /usr/local/libexec/awscli/bin/python -m pip install awscli==1.18.195 \
+ && ln -sv /usr/local/libexec/awscli/bin/aws /usr/local/bin/aws
 
 # Install Snakemake and related optional dependencies.
 # Pinned to 7.32.3 for stability (2023-09-09)
@@ -424,6 +426,9 @@ RUN chmod a+rx /usr/local/bin/* /usr/local/libexec/*
 
 # Add installed Python libs
 COPY --from=builder-target-platform /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
+
+# AWS CLI
+COPY --from=builder-target-platform /usr/local/libexec/awscli/ /usr/local/libexec/awscli/
 
 # Add installed Python scripts that we need.
 #


### PR DESCRIPTION
Otherwise, the awscli → botocore dependency is broken by the subsequent installation of the nextstrain-cli → botocore dependency, which results in --no-sign-request not working as it should.

This approach seemed like the option of least change.  Alternatives to and/or additional improvements to this include a) installing Nextstrain CLI in its own venv instead/as well, b) upgrading to AWS CLI v2 (which is always isolated) or c) updating the nextstrain-cli → botocore dependency to not conflict.

Resolves: <https://github.com/nextstrain/docker-base/issues/213>
Related-to: <https://github.com/nextstrain/docker-base/pull/214>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
