### PR TITLE
ci.yaml: Pin pathogen-repo-ci to v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,13 +219,13 @@ jobs:
           - { pathogen: rsv }
           - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
 
-          # Disable some pathogens until pathogen-repo-ci supports custom build directories
-          # TODO: Re-enable once issue is resolved: https://github.com/nextstrain/.github/issues/63
+          # Disable some pathogens that do not conform to pathogen-repo-ci@v0
+          # TODO: Consider adding a separate job that uses pathogen-repo-ci@v1 for these pathogens
           # - { pathogen: mpox }
           # - { pathogen: zika }
 
     name: test-pathogen-repo-ci (${{ matrix.pathogen }})
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0
     with:
       repo: nextstrain/${{ matrix.pathogen }}
       build-args: ${{ matrix.build-args }}


### PR DESCRIPTION
## Description of proposed changes

Pin the `pathogen-repo-ci` to v0, which is before changes for the "smart" workflow were added.

As a future change, we can consider adding a separate job that uses the latest pathogen-repo-ci to test the currently excluded pathogen repos.

## Related issue(s)

Related to https://github.com/nextstrain/.github/issues/93

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
