### PR TITLE
entrypoint-aws-batch: Upload .snakemake/metadata/ too

### DIFF
--- a/entrypoint-aws-batch
+++ b/entrypoint-aws-batch
@@ -40,8 +40,8 @@ case "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" in
                 return "$zipstatus"
             fi
         }
-        zip -u "$PWD.zip" -r . --exclude ".snakemake/*"     || succeed-when-nothing-to-update $?
-        zip -u "$PWD.zip" -r . --include ".snakemake/log/*" || succeed-when-nothing-to-update $?
+        zip -u "$PWD.zip" -r . --exclude ".snakemake/*"                             || succeed-when-nothing-to-update $?
+        zip -u "$PWD.zip" -r . --include ".snakemake/log/*" ".snakemake/metadata/*" || succeed-when-nothing-to-update $?
         aws s3 cp --no-progress "$PWD.zip" "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL"
         ;;
     s3://*)


### PR DESCRIPTION
Snakemake stores state information per input/output here and uses it to determine if it needs to re-run rules or not.  It seems akin to the file mtimes which we already take care to preserve on upload/download. Additionally, the metadata recorded is used in Snakemake's report generation and is generally useful for looking at workflow statistics.

Continue to not upload all of .snakemake/ en masse because it can potentially contain files that interfere with local usage and/or are large and unnecessary.

Resolves: <https://github.com/nextstrain/cli/issues/373>
Related-to: <https://github.com/nextstrain/cli/pull/374>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
