### PR TITLE
Add pathogen-embed to the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -312,6 +312,7 @@ RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
       ; \
     fi
 
+RUN pip3 install pathogen-embed==2.0.0
 
 # 2. Add unpinned programs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -447,6 +447,9 @@ COPY --from=builder-target-platform \
     /usr/local/bin/nextstrain \
     /usr/local/bin/pangolin \
     /usr/local/bin/pangolearn.smk \
+    /usr/local/bin/pathogen-distance \
+    /usr/local/bin/pathogen-embed \
+    /usr/local/bin/pathogen-cluster \
     /usr/local/bin/scorpio \
     /usr/local/bin/snakemake \
     /usr/local/bin/treetime \


### PR DESCRIPTION
## Description of proposed changes

Adds pathogen-embed to base image, so we can use its tools for analysis of reassortment in our influenza builds.

## Related issue(s)

https://github.com/nextstrain/conda-base/pull/71

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
