### PR TITLE
Update avian flu ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { pathogen: avian-flu,       build-args: test_target }
+          - { pathogen: avian-flu,       build-args: --configfile config/gisaid.yaml -pf test_target }
           - { pathogen: ebola }
           - { pathogen: lassa }
           - { pathogen: mumps }


### PR DESCRIPTION
**Status: Blocked, awaiting merge of <https://github.com/nextstrain/avian-flu/pull/72>**

Mirrors the change in [avian-flu's CI](https://github.com/nextstrain/avian-flu/pull/72). This PR is on top of #223. 



