### PR TITLE
Upgrade IQ-TREE to 2.3.5 with CMAPLE support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN curl -fsSL https://mafft.cbrc.jp/alignment/software/mafft-7.475-linux.tgz \
 # if the processor architecture is not amd64.
 # TODO: Build from source to avoid emulation. Instructions: http://www.iqtree.org/doc/Compilation-Guide
 WORKDIR /download/IQ-TREE
-RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.1.2/iqtree-2.1.2-Linux.tar.gz \
+RUN curl -fsSL https://github.com/iqtree/iqtree2/releases/download/v2.3.5.cmaple/iqtree-2.3.5.cmaple-Linux-intel.tar.gz \
   | tar xzvpf - --no-same-owner --strip-components=1 \
  && mv bin/iqtree2 /final/bin/iqtree
 


### PR DESCRIPTION
We want the CMAPLE support (first available with 2.3.4) for better and faster trees.

CMAPLE support is optional and not all release builds of IQ-TREE have it enabled.  So far, it seems that the "main" releases are made without CMAPLE support (e.g. 2.3.5) and then parallel releases are made with it (e.g. 2.3.5.cmaple), but only for x86_64 on Linux and macOS.  Thus, we're still not using an aarch64/arm64 binary even though the "main" releases (without CMAPLE support) provide them.  If we keep waiting, maybe they'll start being provided, or, eventually, we can start compiling them ourselves.  That's for another time, though.

Resolves: <https://github.com/nextstrain/docker-base/issues/226>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
