### PR TITLE
Remove CVXOPT build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,38 +280,6 @@ RUN pip3 install pysam==0.19.1
 # Install pango_aliasor (for forecasts-ncov)
 RUN pip3 install pango_aliasor==0.3.0
 
-# Build CVXOPT on linux/arm64
-# CVXOPT, an Augur dependency, does not have pre-built binaries for linux/arm64¹.
-#
-# First, add system deps for building²:
-# - gcc: C compiler.
-# - libc6-dev: C libraries and header files.
-# - libopenblas-dev: Contains optimized versions of BLAS and LAPACK.
-# - SuiteSparse: Download the source code so it can be built alongside CVXOPT.
-#
-# Then, "install" (build) separately since the process requires a special
-# environment variable³.
-#
-# ¹ https://github.com/cvxopt/cvxopt-wheels/issues/12
-# ² https://cvxopt.org/install/#building-and-installing-from-source
-# ³ https://cvxopt.org/install/#ubuntu-debian
-#
-# TODO: If this is removed, the installation of libopenblas in the final stage
-# should also be removed.
-WORKDIR /cvxopt
-RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
-      apt-get update && apt-get install -y --no-install-recommends \
-          gcc \
-          libc6-dev \
-          libopenblas-dev \
-   && mkdir SuiteSparse \
-   && curl -fsSL https://api.github.com/repos/DrTimothyAldenDavis/SuiteSparse/tarball/v5.8.1 \
-    | tar xzvpf - --no-same-owner --strip-components=1 -C SuiteSparse \
-   && CVXOPT_SUITESPARSE_SRC_DIR=$(pwd)/SuiteSparse \
-      pip3 install cvxopt==1.3.1 \
-      ; \
-    fi
-
 RUN pip3 install pathogen-embed==3.0.0
 
 # 2. Add unpinned programs
@@ -401,17 +369,6 @@ RUN apt-get update && apt-get install -y ca-certificates curl gnupg \
 
 # Used for platform-specific instructions
 ARG TARGETPLATFORM
-
-# Install CVXOPT deps on linux/arm64
-# CVXOPT, an Augur dependency, was built separately above without runtime deps¹
-# packaged like they are for the amd64 wheel.
-#
-# ¹ https://cvxopt.org/install/#building-and-installing-from-source
-RUN if [[ "$TARGETPLATFORM" == linux/arm64 ]]; then \
-      apt-get update && apt-get install -y --no-install-recommends \
-          libopenblas0 \
-      ; \
-    fi
 
 # Configure bash for interactive usage
 COPY bashrc /etc/bash.bashrc


### PR DESCRIPTION
## Description of proposed changes

manylinux aarch64 wheels are now provided for the CVXOPT version 1.3.2.

## Related issue(s)

- Closes #187

## Checklist

- [x] Checks pass
