### PR TITLE
entrypoint-aws-batch: Keep ../ path parts in ZIP archive members during extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -399,9 +399,17 @@ COPY --from=builder-build-platform /usr/lib/node_modules/ /usr/lib/node_modules/
 # correctly discovered by node.
 RUN ln -sv /usr/lib/node_modules/auspice/auspice.js /usr/local/bin/auspice
 
+# Setup a non-root user for optional use
+RUN useradd nextstrain \
+    --system \
+    --user-group \
+    --shell /bin/bash \
+    --home-dir /nextstrain \
+    --no-log-init
+
 # Add Nextstrain components
-COPY --from=builder-build-platform  /nextstrain /nextstrain
-COPY --from=builder-target-platform /nextstrain /nextstrain
+COPY --from=builder-build-platform  --chown=nextstrain:nextstrain /nextstrain /nextstrain
+COPY --from=builder-target-platform --chown=nextstrain:nextstrain /nextstrain /nextstrain
 
 # Add our entrypoints and helpers
 COPY entrypoint entrypoint-aws-batch drop-privs create-envd delete-envd /sbin/
@@ -410,14 +418,6 @@ RUN chmod a+rx /sbin/entrypoint* /sbin/drop-privs /sbin/{create,delete}-envd
 # Make /nextstrain a global HOME, writable by any UID (like /tmp)
 RUN chmod a+rwXt /nextstrain
 ENV HOME=/nextstrain
-
-# Setup a non-root user for optional use
-RUN useradd nextstrain \
-    --system \
-    --user-group \
-    --shell /bin/bash \
-    --home-dir /nextstrain \
-    --no-log-init
 
 # No nesting of runtimes, please.  Use the ambient runtime inside this runtime.
 ENV NEXTSTRAIN_HOME=/nextstrain

--- a/entrypoint-aws-batch
+++ b/entrypoint-aws-batch
@@ -8,7 +8,7 @@ set -x
 case "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" in
     s3://*.zip)
         aws s3 cp --no-progress "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" "$PWD.zip"
-        unzip -: "$PWD.zip"
+        unzip -: -o "$PWD.zip"
         ;;
     s3://*)
         # Note that this doesn't preserve file permissions/modes.

--- a/entrypoint-aws-batch
+++ b/entrypoint-aws-batch
@@ -8,7 +8,7 @@ set -x
 case "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" in
     s3://*.zip)
         aws s3 cp --no-progress "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" "$PWD.zip"
-        unzip "$PWD.zip"
+        unzip -: "$PWD.zip"
         ;;
     s3://*)
         # Note that this doesn't preserve file permissions/modes.


### PR DESCRIPTION
entrypoint-aws-batch: Keep ../ path parts in ZIP archive members during extraction

The default of stripping ../ parts in member paths is a (good!) restriction for safety and security, but such paths do not pose any (additional) risk in the context of our Nextstrain runtime containers. We're already downloading and executing arbitrary user-supplied code, so the ability to potentially overwrite system files with ZIP archive members is not any additional privilege. And it's only potential at that due to most files being owned by root in the image, not the default container user of nextstrain.

Keeping the ../ parts will allow Nextstrain CLI to construct ZIP archives for jobs which write to new sibling paths of /nextstrain/build in the container. This will be used for including pathogen workflow source separate (e.g. in /nextstrain/pathogen) from the analysis working directory (/nextstrain/build). It can also be used to support Nextstrain CLI's existing --augur, --auspice, etc. overlays on AWS Batch, though a few other changes are required for that too (coming soon).

Note that Nextstrain CLI does *not* permit ../ path parts when extracting from these same ZIP archives (e.g. after a job completes to download results), as that *would* be additional risk. Currently it strips ../ parts, like unzip's default behaviour, but that will change soon to entirely skip archive members containing ../ parts.
