### PR TITLE
Add support for reading/writing parquet files with pyarrow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -262,8 +262,8 @@ RUN pip3 install xlrd==2.0.1
 # Install openpyxl for pandas in GenoFLU
 RUN pip3 install openpyxl==3.1.0
 
-# Install fastparquet for pandas to support parquet files.
-RUN pip3 install fastparquet==2024.11.0
+# Install pyarrow for pandas to support parquet files.
+RUN pip3 install pyarrow==20.0.0
 
 # Install bio, which is used by pathogen builds
 RUN pip3 install bio==1.8.0


### PR DESCRIPTION
## Description of proposed changes

We need support for reading/writing parquet files to prepare submissions to the SARS-CoV-2 variant hub [1]. The pyarrow library is one of two supported by pandas [2] along with fastparquet. The pyarrow library provides a more comprehensive set of tools for the Arrow spec [3], while fastparquet is defined to provide a minimal library for the parquet format. I've opted for the larger pyarrow library here, since it will eventually be a required dependency for pandas [4].

[1] https://github.com/nextstrain/forecasts-ncov/issues/132
[2] https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-parquet
[3] https://arrow.apache.org/docs/cpp/user_guide.html
[4] https://pandas.pydata.org/pdeps/0010-required-pyarrow-dependency.html

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

https://github.com/nextstrain/forecasts-ncov/issues/132

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
