### PR TITLE
Add support for reading/writing parquet files with fastparquet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -262,6 +262,9 @@ RUN pip3 install xlrd==2.0.1
 # Install openpyxl for pandas in GenoFLU
 RUN pip3 install openpyxl==3.1.0
 
+# Install fastparquet for pandas to support parquet files.
+RUN pip3 install fastparquet==2024.11.0
+
 # Install bio, which is used by pathogen builds
 RUN pip3 install bio==1.8.0
 


### PR DESCRIPTION
## Description of proposed changes

We need support for reading/writing parquet files to prepare submissions to the SARS-CoV-2 variant hub [1]. pandas supports two backends for parquet I/O [2] including pyarrow and fastparquet. The pyarrow library provides a more comprehensive set of tools for the Arrow spec [3], while fastparquet is defined to provide a minimal library for the parquet format.

I've opted for the smaller fastparquet library here, since it provides exactly the functionality we need for an additional 4 MB of Docker image size. The pyarrow library will eventually be a required dependency for pandas [4], so we may eventually need to include to that library. However, pyarrow adds 40 MB to the Docker image size most of which is functionality we don't need.

[1] https://github.com/nextstrain/forecasts-ncov/issues/132
[2] https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-parquet
[3] https://arrow.apache.org/docs/cpp/user_guide.html
[4] https://pandas.pydata.org/pdeps/0010-required-pyarrow-dependency.html

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Alternative to #252
Required for https://github.com/nextstrain/forecasts-ncov/issues/132

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
