### PR TITLE
entrypoint-aws-batch: Upload .snakemake/storage/ too 

### DIFF
--- a/entrypoint-aws-batch
+++ b/entrypoint-aws-batch
@@ -52,8 +52,8 @@ case "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL" in
                 return "$zipstatus"
             fi
         }
-        zip -u "$PWD.zip" -r . --exclude ".snakemake/*"                             || succeed-when-nothing-to-update $?
-        zip -u "$PWD.zip" -r . --include ".snakemake/log/*" ".snakemake/metadata/*" || succeed-when-nothing-to-update $?
+        zip -u "$PWD.zip" -r . --exclude ".snakemake/*"                                                    || succeed-when-nothing-to-update $?
+        zip -u "$PWD.zip" -r . --include ".snakemake/log/*" ".snakemake/metadata/*" ".snakemake/storage/*" || succeed-when-nothing-to-update $?
         aws s3 cp --no-progress "$PWD.zip" "$NEXTSTRAIN_AWS_BATCH_WORKDIR_URL"
         ;;
     s3://*)


### PR DESCRIPTION
## Description of proposed changes

When using Snakemakes storage support to download remote files, Snakemake stores 
the downloaded files in `.snakemake/storage` by default. This allows users to 
keep the remote files that were downloaded during the build on AWS Batch.

Note that the storage path is configurable via Snakemake's 
`--local-storage-prefix`.¹ So if someone configures the storage path to a custom 
path within `.snakemake`, e.g. `.snakemake/foo`, then it would not be available 
in their workdir. I'm not sure it's even possible to make this path configurable 
here, so I'm just going to warn against using it from the Nextstrain CLI. 

Related to https://github.com/nextstrain/cli/pull/460

¹ <https://github.com/snakemake/snakemake/blob/v9.6.3/src/snakemake/cli.py#L1456-L1462>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
