### PR TITLE
Make evofr executable available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -390,6 +390,7 @@ COPY --from=builder-target-platform \
     /usr/local/bin/aws \
     /usr/local/bin/bio \
     /usr/local/bin/envdir \
+    /usr/local/bin/evofr \
     /usr/local/bin/nextstrain \
     /usr/local/bin/pathogen-distance \
     /usr/local/bin/pathogen-embed \


### PR DESCRIPTION
## Description of proposed changes

Since evofr v0.1.27, there is a CLI that can be used to run the model. This makes the executable available so that we can directly run the evofr commands.

## Related issue(s)

Related to https://github.com/nextstrain/forecasts-ncov/issues/134

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
