### PR TITLE
Bump csvtk and seqkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ RUN curl -L -o tsv-utils.tar.gz https://github.com/eBay/tsv-utils/releases/downl
 RUN curl -L https://github.com/shenwei356/csvtk/releases/download/v0.35.0/csvtk_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # Download seqkit
-RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.2.0/seqkit_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
+RUN curl -L https://github.com/shenwei356/seqkit/releases/download/v2.10.1/seqkit_${TARGETOS}_${TARGETARCH}.tar.gz | tar xz --no-same-owner -C /final/bin
 
 # 3. Add unpinned programs
 


### PR DESCRIPTION
## Description of proposed changes

Upgrades csvtk and seqkit to latest releases. For csvtk, the newer release provides the `mutate3` subcommand which has better behavior with date expressions than `mutate2`. For seqkit, the newer release reflects 3 years of bug fixes and features since 2022.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
