### PR TITLE
Add python-zstandard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,6 +275,12 @@ RUN pip3 install pyarrow==20.0.0
 # Install bio, which is used by pathogen builds
 RUN pip3 install bio==1.8.0
 
+# Install zstandard, which used to be an indirect dependency of augur
+# until xopen removed it and we pivoted to the stdlib/backport in
+# <https://github.com/nextstrain/augur/pull/2009>
+# Keeping in runtimes to not disrupt use by pathogen builds
+RUN pip3 install zstandard==0.25.0
+
 # 2. Add unpinned programs
 
 # Allow caching to be avoided from here on out in this stage by calling


### PR DESCRIPTION
## Description of proposed changes

Used to be an indirect dependency of Augur, until xopen removed it and we pivoted to the stdlib/backport in
<https://github.com/nextstrain/augur/pull/2009>

Adding here to not disrupt use by pathogen builds and it is already included in conda-base
<https://github.com/nextstrain/conda-base/blob/ede4fa7518fc4e0ccbb6801909f1ecaeef880a7c/src/meta.yaml#L85>
## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
