### PR TITLE
Upgrade to Snakemake v9.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,8 +250,9 @@ RUN python3 -m venv /usr/local/libexec/awscli \
  && ln -sv /usr/local/libexec/awscli/bin/aws /usr/local/bin/aws
 
 # Install Snakemake and related optional dependencies.
-# Pinned to 9.6.2 for stability (latest version on 2025-07-03)
-RUN pip3 install snakemake[reports]==9.6.2
+# Pinned to 9.17.0 for stability, latest guaranteed compatible version
+# based on <https://github.com/nextstrain/public/issues/39>
+RUN pip3 install snakemake[reports]==9.17.0
 # Snakemake plugins for remote storage providers
 # Pinned for stability (latest versions on 2025-07-03)
 RUN pip3 install snakemake-storage-plugin-http==0.3.0


### PR DESCRIPTION

## Description of proposed changes

Mainly motivated by upgrading past v9.11.0 that no longer has fstring bug discussed in Slack.¹

We've already updated all pathogen workflows to be compatible with v9.17.0 as part of <https://github.com/nextstrain/public/issues/39> so this should not have any breaking changes.

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1781824491104269>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
